### PR TITLE
feat(router): implement router

### DIFF
--- a/router/basic.go
+++ b/router/basic.go
@@ -1,0 +1,226 @@
+package router
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+)
+
+// Handler contains middlewares and executor.
+type Handler struct {
+	Middlewares []Middleware
+	Executor    Executor
+}
+
+// AddMiddleware adds middleware to the router node.
+// If the router matches a path, all middlewares in the router
+// will be executed by the returned executor.
+func (h *Handler) AddMiddleware(ms ...Middleware) {
+	h.Middlewares = append(h.Middlewares, ms...)
+}
+
+// AddExecutor adds executor to the router node.
+// A router can hold many executors, but there is only one executor
+// is selected for a match.
+func (h *Handler) AddExecutor(es ...Executor) {
+	var executors Executors
+	if h.Executor != nil {
+		if array, ok := h.Executor.(Executors); ok {
+			executors = array
+		} else {
+			executors = Executors{h.Executor}
+		}
+	}
+	for _, e := range es {
+		if e != nil {
+			if array, ok := e.(Executors); ok {
+				executors = append(executors, array...)
+			} else {
+				executors = append(executors, e)
+			}
+		}
+	}
+	if executors != nil {
+		h.Executor = executors
+	}
+}
+
+// Merge merges middlewares and executors.
+func (h *Handler) Merge(o *Handler) {
+	h.AddMiddleware(o.Middlewares...)
+	h.AddExecutor(o.Executor)
+}
+
+// Pack packs middlewares with the executor.
+func (h *Handler) Pack(e Executor) Executor {
+	if e == nil {
+		return nil
+	}
+	if len(h.Middlewares) <= 0 {
+		return e
+	}
+	return NewMiddlewareExecutor(h.Middlewares, e)
+}
+
+// UnionExecutor packs middlewares and own executor.
+func (h *Handler) UnionExecutor(ctx context.Context) Executor {
+	if h.Executor == nil {
+		return nil
+	}
+	e, ok := h.Executor.Inspect(ctx)
+	if !ok {
+		return nil
+	}
+	return h.Pack(e)
+}
+
+// CharRouter
+type CharRouter struct {
+	Char   byte
+	Router *StringNode
+}
+
+// Progeny contains all children routers.
+type Progeny struct {
+	StringRouters []CharRouter
+	RegexpRouters []Router
+	PathRouter    Router
+}
+
+// FindStringRouter find a router by first char.
+func (p *Progeny) FindStringRouter(char byte) Router {
+	length := len(p.StringRouters)
+	if length <= 3 {
+		// If the length is less than 3, use linear search.
+		for _, cr := range p.StringRouters {
+			if cr.Char == char {
+				return cr.Router
+			}
+		}
+		return nil
+	}
+	// Binary search.
+	index := sort.Search(len(p.StringRouters), func(i int) bool {
+		return char <= p.StringRouters[i].Char
+	})
+	if index >= length {
+		return nil
+	}
+	target := p.StringRouters[index]
+	if char != target.Char {
+		return nil
+	}
+	return target.Router
+}
+
+// Match find an executor matched by path.
+// The context contains information to inspect executor.
+// The container can save key-value pair from the path.
+// If the router is the leaf node to match the path, it will return
+// the first executor which Inspect() returns true.
+func (p *Progeny) Match(ctx context.Context, c Container, path string) Executor {
+	if len(path) <= 0 {
+		return nil
+	}
+
+	// Match string routers
+	if len(p.StringRouters) > 0 {
+		if router := p.FindStringRouter(path[0]); router != nil {
+			if executor := router.Match(ctx, c, path); executor != nil {
+				return executor
+			}
+		}
+	}
+
+	// Match regexp routers
+	for _, regexp := range p.RegexpRouters {
+		if executor := regexp.Match(ctx, c, path); executor != nil {
+			return executor
+		}
+	}
+
+	// Match path router
+	if p.PathRouter != nil {
+		return p.PathRouter.Match(ctx, c, path)
+	}
+	return nil
+}
+
+//  AddRouter adds a router to current progeny.
+func (p *Progeny) AddRouter(router Router) {
+	switch router.Kind() {
+	case String:
+		target := router.Target()
+		if len(target) <= 0 {
+			panic("invalid router target")
+		}
+		r, ok := router.(*StringNode)
+		if !ok {
+			panic(fmt.Sprintf("unknown string node: %s", reflect.TypeOf(router).String()))
+		}
+		c := target[0]
+		sr := p.FindStringRouter(c)
+		if sr != nil {
+			_, err := sr.Merge(router)
+			if err != nil {
+				panic(err.Error())
+			}
+			return
+		}
+		length := len(p.StringRouters)
+		index := 0
+		if length > 0 {
+			index = sort.Search(length, func(i int) bool {
+				return c < p.StringRouters[i].Char
+			})
+		}
+		cr := CharRouter{c, r}
+		if index >= length {
+			p.StringRouters = append(p.StringRouters, cr)
+		} else {
+			p.StringRouters = append(p.StringRouters[:index+1], p.StringRouters[index:]...)
+			p.StringRouters[index] = cr
+		}
+	case Regexp:
+		found := false
+		for _, r := range p.RegexpRouters {
+			if r.Target() == router.Target() {
+				_, err := r.Merge(router)
+				if err != nil {
+					panic(err.Error())
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			p.RegexpRouters = append(p.RegexpRouters, router)
+		}
+	case Path:
+		if p.PathRouter != nil {
+			r, err := p.PathRouter.Merge(router)
+			if err != nil {
+				panic(fmt.Sprintf("failed to merge path router : %s", err.Error()))
+			}
+			p.PathRouter = r
+		} else {
+			p.PathRouter = router
+		}
+	default:
+		panic(fmt.Sprintf("unknwon router kind: %s", router.Kind()))
+	}
+}
+
+// Merge merges children routers.
+func (p *Progeny) Merge(o *Progeny) {
+	for _, r := range o.StringRouters {
+		p.AddRouter(r.Router)
+	}
+	for _, r := range o.RegexpRouters {
+		p.AddRouter(r)
+	}
+	if o.PathRouter != nil {
+		p.AddRouter(o.PathRouter)
+	}
+}

--- a/router/executor.go
+++ b/router/executor.go
@@ -1,0 +1,68 @@
+package router
+
+import "context"
+
+// MiddlewareExecutor is a combination of middlewares and executor.
+type MiddlewareExecutor struct {
+	// Middlewares contains all middlewares for the executor.
+	Middlewares []Middleware
+	// Index is used to record the count of executed middleware.
+	Index int
+	// Executor executes after middlewares.
+	Executor
+}
+
+// NewMiddlewareExecutor creates a new executor with middlewares.
+func NewMiddlewareExecutor(ms []Middleware, e Executor) Executor {
+	return &MiddlewareExecutor{ms, 0, e}
+}
+
+// Inspect checks whether the executor can executes with the context.
+func (me *MiddlewareExecutor) Inspect(c context.Context) (Executor, bool) {
+	if _, ok := me.Executor.Inspect(c); !ok {
+		return nil, false
+	}
+	return me, true
+}
+
+// Execute executes middlewares and executor.
+func (me *MiddlewareExecutor) Execute(c context.Context) error {
+	me.Index = 0
+	return me.Continue(c)
+}
+
+// Continue continues to execute the next middleware or executor.
+func (me *MiddlewareExecutor) Continue(c context.Context) error {
+	if me.Index >= len(me.Middlewares) {
+		if me.Executor != nil {
+			return me.Executor.Execute(c)
+		}
+		return nil
+	}
+	m := me.Middlewares[me.Index]
+	me.Index++
+	return m(c, me)
+}
+
+// Executors is a list of executors.
+type Executors []Executor
+
+// Inspect finds an appropriate executor from the list.
+func (e Executors) Inspect(c context.Context) (Executor, bool) {
+	for _, executor := range e {
+		if result, ok := executor.Inspect(c); ok {
+			return result, true
+		}
+	}
+	return nil, false
+}
+
+// Execute executes the fisrt appropriate executor.
+func (e Executors) Execute(c context.Context) error {
+	for _, executor := range e {
+		if result, ok := executor.Inspect(c); ok {
+			return result.Execute(c)
+		}
+	}
+	return nil
+}

--- a/router/path.go
+++ b/router/path.go
@@ -1,0 +1,48 @@
+package router
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+)
+
+// PathNode matches all rest path.
+type PathNode struct {
+	Handler
+	// Key is the key for the rest path.
+	Key string
+}
+
+// Target returns the matching target of the node.
+func (n *PathNode) Target() string {
+	return ""
+}
+
+// Kind returns the kind of the router node.
+func (n *PathNode) Kind() RouterKind {
+	return Path
+}
+
+// Match find an executor matched by path.
+// The context contains information to inspect executor.
+// The container can save key-value pair from the path.
+// If the router is the leaf node to match the path, it will return
+// the first executor which Inspect() returns true.
+func (n *PathNode) Match(ctx context.Context, c Container, path string) Executor {
+	c.Set(n.Key, path)
+	return n.Handler.UnionExecutor(ctx)
+}
+
+// Merge merges r to the current router. The type of r should be same
+// as the current one.
+func (n *PathNode) Merge(r Router) (Router, error) {
+	node, ok := r.(*PathNode)
+	if !ok {
+		return nil, fmt.Errorf("unrecognized path router: %s", reflect.TypeOf(r).String())
+	}
+	if n.Key != node.Key {
+		return nil, fmt.Errorf("unmatched path key: %s %s", n.Key, node.Key)
+	}
+	n.Handler.Merge(&node.Handler)
+	return n, nil
+}

--- a/router/regexp.go
+++ b/router/regexp.go
@@ -1,0 +1,145 @@
+package router
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+)
+
+// Index contains the key and it's index of the submatches.
+type Index struct {
+	// Key is the name for the value.
+	Key string
+	// Pos is the index of value in submatches.
+	Pos int
+}
+
+// RegexpNode contains infomation for matching a regexp segment.
+type RegexpNode struct {
+	Handler
+	Progeny
+	// Indices contains all positions to get values from submatches.
+	Indices []Index
+	// Exp is the regular expression.
+	Exp string
+	// Regexp is a regexp instance to match.
+	Regexp *regexp.Regexp
+}
+
+// Target returns the matching target of the node.
+func (n *RegexpNode) Target() string {
+	return n.Exp
+}
+
+// Kind returns the kind of the router node.
+func (n *RegexpNode) Kind() RouterKind {
+	return Regexp
+}
+
+// Match find an executor matched by path.
+// The context contains information to inspect executor.
+// The container can save key-value pair from the path.
+// If the router is the leaf node to match the path, it will return
+// the first executor which Inspect() returns true.
+func (n *RegexpNode) Match(ctx context.Context, c Container, path string) Executor {
+	// Match self
+	index := strings.IndexByte(path, '/')
+	if index < 0 {
+		index = len(path)
+	}
+	segment := path[:index]
+	result := n.Regexp.FindStringSubmatch(segment)
+	if result == nil {
+		return nil
+	}
+	// Match progeny
+	var executor Executor
+	if index < len(path) {
+		executor = n.Handler.Pack(n.Progeny.Match(ctx, c, path[index:]))
+	} else {
+		executor = n.UnionExecutor(ctx)
+	}
+
+	if executor == nil {
+		// Unmatched
+		return nil
+	}
+
+	// Set values
+	for _, i := range n.Indices {
+		c.Set(i.Key, result[i.Pos])
+	}
+	return executor
+}
+
+// Merge merges r to the current router. The type of r should be same
+// as the current one or it panics.
+func (n *RegexpNode) Merge(r Router) (Router, error) {
+	node, ok := r.(*RegexpNode)
+	if !ok {
+		return nil, fmt.Errorf("unrecognized regexp router: %s", reflect.TypeOf(r).String())
+	}
+	if n.Exp != node.Exp {
+		return nil, fmt.Errorf("unmatched regexp: %s %s", n.Exp, node.Exp)
+	}
+	n.Handler.Merge(&node.Handler)
+	n.Progeny.Merge(&node.Progeny)
+	return n, nil
+}
+
+// FullMatchRegexpNode is an optimizing of RegexpNode.
+type FullMatchRegexpNode struct {
+	Handler
+	Progeny
+	// Key is the name for the only value.
+	Key string
+}
+
+// Target returns the matching target of the node.
+func (n *FullMatchRegexpNode) Target() string {
+	return (&ExpSegment{FullMatchTarget, n.Key}).Target()
+}
+
+// Kind returns the kind of the router node.
+func (n *FullMatchRegexpNode) Kind() RouterKind {
+	return Regexp
+}
+
+// Match find an executor matched by path.
+// The context contains information to inspect executor.
+// The container can save key-value pair from the path.
+// If the router is the leaf node to match the path, it will return
+// the first executor which Inspect() returns true.
+func (n *FullMatchRegexpNode) Match(ctx context.Context, c Container, path string) Executor {
+	index := strings.IndexByte(path, '/')
+	var executor Executor
+	if index > 0 {
+		executor = n.Handler.Pack(n.Progeny.Match(ctx, c, path[index:]))
+	} else {
+		index = len(path)
+		executor = n.UnionExecutor(ctx)
+	}
+	if executor == nil {
+		// Unmatched
+		return nil
+	}
+	c.Set(n.Key, path[:index])
+	return executor
+}
+
+// Merge merges r to the current router. The type of r should be same
+// as the current one or it panics.
+func (n *FullMatchRegexpNode) Merge(r Router) (Router, error) {
+	node, ok := r.(*FullMatchRegexpNode)
+	if !ok {
+		return nil, fmt.Errorf("unrecognized full match router: %s", reflect.TypeOf(r).String())
+	}
+	if n.Key != node.Key {
+		return nil, fmt.Errorf("unmatched full match key: %s %s", n.Key, node.Key)
+	}
+	n.Handler.Merge(&node.Handler)
+	n.Progeny.Merge(&node.Progeny)
+	return n, nil
+}

--- a/router/router.go
+++ b/router/router.go
@@ -1,0 +1,318 @@
+/*
+Copyright 2017 caicloud authors. All rights reserved.
+*/
+
+package router
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+)
+
+// RoutingChain contains the call chain of middlewares and executor.
+type RoutingChain interface {
+	// Continue continues to execute the next middleware or executor.
+	Continue(context.Context) error
+}
+
+// Middleware describes the form of middlewares. If you want to
+// carry on, call RoutingChain.Continue() and pass the context.
+type Middleware func(context.Context, RoutingChain) error
+
+// Executor is an executor for a request.
+type Executor interface {
+	// Inspect finds a valid executor to execute target context.
+	Inspect(context.Context) (Executor, bool)
+	// Execute executes with context.
+	Execute(context.Context) error
+}
+
+// RouterKind is kind of routers.
+type RouterKind string
+
+const (
+	// String means the router has a fixed string.
+	String RouterKind = "String"
+	// Regexp means the router has a regular expression.
+	Regexp RouterKind = "Regexp"
+	// Path means the router matches the rest. Path router only can
+	// be placed at the leaf node.
+	Path RouterKind = "Path"
+)
+
+// Container is a key-value container. It saves key-values from path.
+type Container interface {
+	// Set sets key-value into the container.
+	Set(key, value string)
+	// Get gets a value by key from the container.
+	Get(key string) (string, bool)
+}
+
+// Router describes the interface of a router node.
+type Router interface {
+	// Target returns the matching target of the node.
+	// It can be a fixed string or a regular expression.
+	Target() string
+	// Kind returns the kind of the router node.
+	Kind() RouterKind
+	// Match find an executor matched by path.
+	// The context contains information to inspect executor.
+	// The container can save key-value pair from the path.
+	// If the router is the leaf node to match the path, it will return
+	// the first executor which Inspect() returns true.
+	Match(ctx context.Context, c Container, path string) Executor
+	// AddMiddleware adds middleware to the router node.
+	// If the router matches a path, all middlewares in the router
+	// will be executed by the returned executor.
+	AddMiddleware(ms ...Middleware)
+	// AddExecutor adds executor to the router node.
+	// A router can hold many executors, but there is only one executor
+	// is selected for a match.
+	AddExecutor(es ...Executor)
+	// Merge merges r to the current router. The type of r should be same
+	// as the current one or it panics.
+	//
+	// For instance:
+	//  Router A: /namespaces/ -> {namespace}
+	//  Router B: /nameless/ -> {other}
+	// Result:
+	//  /name -> spaces/ -> {namespace}
+	//       |-> less/ -> {other}
+	Merge(r Router) (Router, error)
+}
+
+const (
+	// Default match regular expression. All regexp router without expression
+	// will use the expression.
+	FullMatchTarget = ".*"
+	// Tail match expression.
+	TailMatchTarget = "*"
+)
+
+// Parse parses a path to a router tree. It returns the root router and
+// the leaf router. you can add middlewares and executor to the routers.
+// A valid path should like:
+//  /segments/{segment}/resources/{resource}
+//  /segments/{segment:[a-z]{1,2}}.log/paths/{path:*}
+func Parse(path string) (Router, Router, error) {
+	paths, err := Split(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(paths) <= 0 {
+		return nil, nil, fmt.Errorf("invalid path")
+	}
+	segments, err := Reorganize(paths)
+	if err != nil {
+		return nil, nil, err
+	}
+	var root Router
+	var leaf Router
+	var parent Router
+	for i, seg := range segments {
+		router, err := SegmentToRouter(seg)
+		if err != nil {
+			return nil, nil, err
+		}
+		if i == 0 {
+			root = router
+		}
+		if i == len(segments)-1 {
+			leaf = router
+		}
+		if parent != nil {
+			if c, ok := parent.(interface {
+				AddRouter(router Router)
+			}); ok {
+				c.AddRouter(router)
+			} else {
+				return nil, nil, fmt.Errorf("router does not implement RouterContainer: %s", reflect.TypeOf(parent).String())
+			}
+		}
+		parent = router
+	}
+	return root, leaf, nil
+}
+
+// SegmentToRouter converts segment to a router.
+func SegmentToRouter(seg *Segment) (Router, error) {
+	switch seg.Kind {
+	case String:
+		return &StringNode{
+			Prefix: seg.Match,
+		}, nil
+	case Regexp:
+		if len(seg.Keys) == 1 && seg.Match == (&ExpSegment{FullMatchTarget, seg.Keys[0]}).Target() {
+			return &FullMatchRegexpNode{
+				Key: seg.Keys[0],
+			}, nil
+		} else {
+			node := &RegexpNode{
+				Exp: seg.Match,
+			}
+			r, err := regexp.Compile("^" + seg.Match + "$")
+			if err != nil {
+				return nil, err
+			}
+			node.Regexp = r
+			names := r.SubexpNames()
+			j := 0
+			for i := 0; i < len(names) && j < len(seg.Keys); i++ {
+				if names[i] == seg.Keys[j] {
+					node.Indices = append(node.Indices, Index{names[i], i})
+					j++
+				}
+			}
+			if j != len(seg.Keys) {
+				return nil, fmt.Errorf("unmatched keys: %+v", seg)
+			}
+			return node, nil
+		}
+	case Path:
+		return &PathNode{
+			Key: seg.Keys[0],
+		}, nil
+	}
+	return nil, fmt.Errorf("unknown segment: %+v", seg)
+}
+
+// Split splits string segments and regexp segments.
+//
+// For instance:
+//  /segments/{segment:[a-z]{1,2}}.log/paths/{path:*}
+// TO:
+//  /segments/ {segment:[a-z]{1,2}} .log/paths/ {path:*}
+func Split(path string) ([]string, error) {
+	result := make([]string, 0, 5)
+	lastElementPos := 0
+	braceCounter := 0
+	for i, c := range path {
+		switch c {
+		case '{':
+			braceCounter++
+			if braceCounter == 1 {
+				result = append(result, path[lastElementPos:i])
+				lastElementPos = i
+			}
+		case '}':
+			braceCounter--
+			if braceCounter == 0 {
+				result = append(result, path[lastElementPos:i+1])
+				lastElementPos = i + 1
+			}
+		}
+	}
+	if braceCounter > 0 {
+		return nil, fmt.Errorf("unmatched braces")
+	}
+	if lastElementPos < len(path) {
+		result = append(result, path[lastElementPos:])
+	}
+	return result, nil
+}
+
+// Segment contains infomation to construct a router.
+type Segment struct {
+	// Match is the target string.
+	Match string
+	// Keys contains keys from segments.
+	Keys []string
+	// Kind is the router kind which the segment can be converted to.
+	Kind RouterKind
+}
+
+// Reorganize reorganizes the form of paths.
+//
+// For instance:
+//  /segments/ {segment:[a-z]{1,2}} .log/paths/ {path:*}
+// To:
+//  {/segments/ {} String} {(?P<segment>[a-z]{1,2})\.log {segment} Regexp} {/paths/ {} String} { {path} Path}
+func Reorganize(paths []string) ([]*Segment, error) {
+	segments := make([]*Segment, 0, len(paths))
+	var segment *Segment
+	for i := 0; i < len(paths); i++ {
+		p := paths[i]
+		if !strings.HasPrefix(p, "{") {
+			if segment == nil {
+				// String segment
+				segments = append(segments, &Segment{p, nil, String})
+			} else {
+				// Regexp segment
+				slashPos := strings.Index(p, "/")
+				if slashPos < 0 {
+					// No slash
+					segment.Match += regexp.QuoteMeta(p)
+				} else {
+					segment.Match += regexp.QuoteMeta(p[:slashPos])
+					segments = append(segments, segment, &Segment{p[slashPos:], nil, String})
+					segment = nil
+				}
+			}
+		} else {
+			// Regexp segment
+			seg, err := ParseExpSegment(p)
+			if err != nil {
+				return nil, err
+			}
+			if seg.Tail() {
+				if i != len(paths)-1 {
+					return nil, fmt.Errorf("key %s should be last element in the path", seg.Key)
+				}
+				if segment != nil {
+					segments = append(segments, segment)
+					segment = nil
+				}
+				segments = append(segments, &Segment{"", []string{seg.Key}, Path})
+				break
+			}
+			if segment == nil {
+				segment = &Segment{"", []string{}, Regexp}
+			}
+			segment.Match += seg.Target()
+			segment.Keys = append(segment.Keys, seg.Key)
+		}
+	}
+	if segment != nil {
+		segments = append(segments, segment)
+	}
+	return segments, nil
+}
+
+// ExpSegment describes a regexp segment.
+type ExpSegment struct {
+	// Exp is the regular expression.
+	Exp string
+	// Key is the key for the expression.
+	Key string
+}
+
+// ParseExpSegment parses a regexp segment to ExpSegment.
+func ParseExpSegment(exp string) (*ExpSegment, error) {
+	if !strings.HasPrefix(exp, "{") || !strings.HasSuffix(exp, "}") {
+		return nil, fmt.Errorf("exp does not have normative format: %s", exp)
+	}
+	exp = exp[1 : len(exp)-1]
+	pos := strings.Index(exp, ":")
+	seg := &ExpSegment{}
+	if pos < 0 {
+		seg.Exp = FullMatchTarget
+		seg.Key = exp
+	} else {
+		seg.Exp = exp[pos+1:]
+		seg.Key = exp[:pos]
+	}
+	return seg, nil
+}
+
+// Tail returns whether the segment contains a tail match target.
+func (es *ExpSegment) Tail() bool {
+	return es.Exp == TailMatchTarget
+}
+
+// Target returns the whole regular expression for the segment.
+func (es *ExpSegment) Target() string {
+	return fmt.Sprintf("(?P<%s>%s)", es.Key, es.Exp)
+}

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1,0 +1,304 @@
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestSplit(t *testing.T) {
+	paths := []string{
+		"/segments/segment/resources/resource",
+		"/segments/{segment}/resources/{resource}",
+		"/segments/{segment:[a-z]{1,2}}.log{temp}sss/paths/{path:*}",
+	}
+	results := [][]string{
+		{"/segments/segment/resources/resource"},
+		{"/segments/", "{segment}", "/resources/", "{resource}"},
+		{"/segments/", "{segment:[a-z]{1,2}}", ".log", "{temp}", "sss/paths/", "{path:*}"},
+	}
+	for i, p := range paths {
+		result, err := Split(p)
+		if err != nil {
+			t.Fatalf("Untracked error: %s", err.Error())
+		}
+		want := results[i]
+		if len(result) != len(want) {
+			t.Fatalf("Length is not equal for url: %s", p)
+		}
+		t.Log(result)
+		t.Log(want)
+		for j := 0; j < len(result); j++ {
+			if result[j] != want[j] {
+				t.Fatalf("The split result is incorrect: %v,%v", result, want)
+			}
+		}
+	}
+}
+
+func TestReorganize(t *testing.T) {
+	paths := [][]string{
+		{"/segments/segment/resources/resource"},
+		{"/segments/", "{segment}", "/resources/", "{resource}"},
+		{"/segments/", "{segment:[a-z]{1,2}}", ".log", "{temp}", "sss/paths/", "{path:*}"},
+	}
+	results := [][]*Segment{
+		{{"/segments/segment/resources/resource", nil, String}},
+		{
+			{"/segments/", nil, String},
+			{"(?P<segment>.*)", []string{"segment"}, Regexp},
+			{"/resources/", nil, String},
+			{"(?P<resource>.*)", []string{"resource"}, Regexp},
+		},
+		{
+			{"/segments/", nil, String},
+			{`(?P<segment>[a-z]{1,2})\.log(?P<temp>.*)sss`, []string{"segment", "temp"}, Regexp},
+			{"/paths/", nil, String},
+			{"", []string{"path"}, Path},
+		},
+	}
+	for i, p := range paths {
+		result, err := Reorganize(p)
+		if err != nil {
+			t.Fatalf("Untracked error: %s", err.Error())
+		}
+		want := results[i]
+		if len(result) != len(want) {
+			t.Fatalf("Length is not equal for path: %v", p)
+		}
+		for j := 0; j < len(result); j++ {
+			t.Logf("%+v", result[j])
+			t.Logf("%+v", want[j])
+			if !reflect.DeepEqual(result[j], want[j]) {
+				t.Fatalf("The split result is incorrect: %v", p)
+			}
+		}
+	}
+
+}
+
+func TestParse(t *testing.T) {
+	path := "/segments/{cmd}/{segment:[a-z]{1,2}}.log{temp}sss/paths/{path:*}"
+	root, leaf, err := Parse(path)
+	if err != nil {
+		t.Fatalf("Untracked error: %s", err.Error())
+	}
+	router := root
+
+	if r, ok := router.(*StringNode); !ok {
+		t.Fatalf("Invalid node type: %s", reflect.TypeOf(router).String())
+	} else {
+		if r.Target() != "/segments/" {
+			t.Fatalf("Invalid router target")
+		}
+		if len(r.RegexpRouters) != 1 {
+			t.Fatalf("Invalid children router")
+		}
+		router = r.RegexpRouters[0]
+		t.Log(r.Target())
+	}
+
+	if r, ok := router.(*FullMatchRegexpNode); !ok {
+		t.Fatalf("Invalid node type: %s", reflect.TypeOf(router).String())
+	} else {
+		if r.Target() != (&ExpSegment{FullMatchTarget, r.Key}).Target() {
+			t.Fatalf("Invalid router target")
+		}
+		if len(r.StringRouters) != 1 {
+			t.Fatalf("Invalid children router")
+		}
+		router = r.StringRouters[0].Router
+		t.Log(r.Target())
+	}
+
+	if r, ok := router.(*StringNode); !ok {
+		t.Fatalf("Invalid node type: %s", reflect.TypeOf(router).String())
+	} else {
+		if r.Target() != "/" {
+			t.Fatalf("Invalid router target")
+		}
+		if len(r.RegexpRouters) != 1 {
+			t.Fatalf("Invalid children router")
+		}
+		router = r.RegexpRouters[0]
+		t.Log(r.Target())
+	}
+
+	if r, ok := router.(*RegexpNode); !ok {
+		t.Fatalf("Invalid node type: %s", reflect.TypeOf(router).String())
+	} else {
+		if r.Target() != `(?P<segment>[a-z]{1,2})\.log(?P<temp>.*)sss` {
+			t.Fatalf("Invalid router target")
+		}
+		if len(r.StringRouters) != 1 {
+			t.Fatalf("Invalid children router")
+		}
+		router = r.StringRouters[0].Router
+		t.Log(r.Target())
+	}
+
+	if r, ok := router.(*StringNode); !ok {
+		t.Fatalf("Invalid node type: %s", reflect.TypeOf(router).String())
+	} else {
+		if r.Target() != "/paths/" {
+			t.Fatalf("Invalid router target")
+		}
+		if r.PathRouter == nil {
+			t.Fatalf("Invalid children router")
+		}
+		router = r.PathRouter
+		t.Log(r.Target())
+	}
+
+	if r, ok := router.(*PathNode); !ok {
+		t.Fatalf("Invalid node type: %s", reflect.TypeOf(router).String())
+	} else {
+		if r.Target() != "" {
+			t.Fatalf("Invalid router target")
+		}
+		if r != leaf {
+			t.Fatalf("Invalid router: %s", reflect.TypeOf(router).String())
+		}
+		t.Log(r.Target())
+	}
+}
+
+func TestRouter(t *testing.T) {
+	rds := []TestRouterData{
+		{"/api/v1/namespaces", &TestExecutor{"GET", 1}},
+		{"/api/v1/namespaces/{namespace}", &TestExecutor{"POST", 2}},
+		{"/api/v1/namespaces/{namespace2:one[3456]?}/subjects", &TestExecutor{"CONNECT", 200}},
+		{"/api/v1/namespaces/{namespace}/objects", &TestExecutor{"PUT", 3}},
+		{"/api/v1/namespaces/{namespace}/objects/{object:*}", &TestExecutor{"DELETE", 4}},
+		{"/api/v1/namespaces", &TestExecutor{"POST", 100}},
+		{"/api/v1/namespaces/{namespace}/objects/{object:*}", &TestExecutor{"PUT", 400}},
+		{"/api/v1/namespaces/{namespace2:one[3456]?}/subjects", &TestExecutor{"GET", 201}},
+	}
+	right := []TestData{
+		{"/api/v1/namespaces", "GET", 1, map[string]string{}},
+		{"/api/v1/namespaces", "POST", 100, map[string]string{}},
+		{"/api/v1/namespaces/one", "POST", 2, map[string]string{"namespace": "one"}},
+		{"/api/v1/namespaces/one/subjects", "CONNECT", 200, map[string]string{"namespace2": "one"}},
+		{"/api/v1/namespaces/one3/subjects", "CONNECT", 200, map[string]string{"namespace2": "one3"}},
+		{"/api/v1/namespaces/one5/subjects", "CONNECT", 200, map[string]string{"namespace2": "one5"}},
+		{"/api/v1/namespaces/one4/subjects", "GET", 201, map[string]string{"namespace2": "one4"}},
+		{"/api/v1/namespaces/one/objects", "PUT", 3, map[string]string{"namespace": "one"}},
+		{"/api/v1/namespaces/one/objects/two", "DELETE", 4, map[string]string{"namespace": "one", "object": "two"}},
+		{"/api/v1/namespaces/one/objects/two2", "PUT", 400, map[string]string{"namespace": "one", "object": "two2"}},
+	}
+	wrong := []TestData{
+		{"/api/v1/namespaces/", "GET", 0, nil},
+		{"/api/v1/namespaces/one3/subjects", "POST", 0, nil},
+		{"/api/v1/namespaces/one1/subjects", "CONNECT", 0, nil},
+		{"/api/v1/namespaces/one12/subjects", "CONNECT", 0, nil},
+		{"/api/v1/namespaces/", "GET", 0, nil},
+		{"/api/v1/namespaces", "PUT", 0, nil},
+	}
+
+	var root Router
+	for _, d := range rds {
+		router, leaf, err := Parse(d.Path)
+		if err != nil {
+			t.Fatalf("Untracked error: %s", err.Error())
+		}
+		leaf.AddExecutor(d.Executor)
+		if root == nil {
+			root = router
+		} else {
+			root.Merge(router)
+		}
+	}
+	rj, err := json.Marshal(root)
+	if err != nil {
+		t.Fatalf("Can't Marshal router: %s", err.Error())
+	}
+	t.Logf("%s", string(rj))
+
+	for _, d := range right {
+		values := NewTestValueContainer()
+		ctx := context.WithValue(context.Background(), "Type", d.Type)
+		e := root.Match(ctx, values, d.Path)
+		if e == nil {
+			t.Fatalf("Can't match path: %s", d.Path)
+		}
+		for k, v := range d.Values {
+			pv, ok := values.Get(k)
+			if !ok || pv != v {
+				t.Fatalf("Can't match path with values: %s(%+v, %+v)", d.Path, d.Values, values)
+			}
+		}
+		result := 0
+		ctx = context.WithValue(ctx, "Result", &result)
+		err := e.Execute(ctx)
+		if err != nil {
+			t.Fatalf("Untracked error: %s", err.Error())
+		}
+		if result != d.Result {
+			t.Fatalf("Executor returns an invalid value: %d, Expect: %d", result, d.Result)
+		}
+	}
+
+	for _, d := range wrong {
+		values := NewTestValueContainer()
+		ctx := context.WithValue(context.Background(), "Type", d.Type)
+		e := root.Match(ctx, values, d.Path)
+		if e != nil {
+			t.Logf("%+v", e)
+			t.Fatalf("Matched by mistake: %s", d.Path)
+		}
+	}
+}
+
+type TestData struct {
+	Path   string
+	Type   string
+	Result int
+	Values map[string]string
+}
+
+type TestRouterData struct {
+	Path     string
+	Executor *TestExecutor
+}
+
+type TestValueContainer struct {
+	Data map[string]string
+}
+
+func NewTestValueContainer() *TestValueContainer {
+	return &TestValueContainer{
+		make(map[string]string),
+	}
+}
+func (tvc *TestValueContainer) Set(key, value string) {
+	tvc.Data[key] = value
+}
+
+func (tvc *TestValueContainer) Get(key string) (string, bool) {
+	v, ok := tvc.Data[key]
+	return v, ok
+}
+
+type TestExecutor struct {
+	Type   string
+	Result int
+}
+
+func (te *TestExecutor) Inspect(c context.Context) (Executor, bool) {
+	ins := c.Value("Type")
+	if typ, ok := ins.(string); ok && typ == te.Type {
+		return te, true
+	}
+	return nil, false
+}
+
+func (te *TestExecutor) Execute(c context.Context) error {
+	result := c.Value("Result")
+	if pointer, ok := result.(*int); ok {
+		*pointer = te.Result
+	} else {
+		panic("can't find result from context")
+	}
+	return nil
+}

--- a/router/string.go
+++ b/router/string.go
@@ -1,0 +1,86 @@
+package router
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// StringNode describes a string router node.
+type StringNode struct {
+	Handler
+	Progeny
+	// Prefix is the fixed string to match path.
+	Prefix string
+}
+
+// Target returns the matching target of the node.
+func (n *StringNode) Target() string {
+	return n.Prefix
+}
+
+// Kind returns the kind of the router node.
+func (n *StringNode) Kind() RouterKind {
+	return String
+}
+
+// Match find an executor matched by path.
+// The context contains information to inspect executor.
+// The container can save key-value pair from the path.
+// If the router is the leaf node to match the path, it will return
+// the first executor which Inspect() returns true.
+func (n *StringNode) Match(ctx context.Context, c Container, path string) Executor {
+	if n.Prefix != "" && !strings.HasPrefix(path, n.Prefix) {
+		// No match
+		return nil
+	}
+	if len(n.Prefix) < len(path) {
+		// Match prefix
+		return n.Handler.Pack(n.Progeny.Match(ctx, c, path[len(n.Prefix):]))
+	}
+	// Match self
+	return n.Handler.UnionExecutor(ctx)
+}
+
+// Merge merges r to the current router. The type of r should be same
+// as the current one or it panics.
+func (n *StringNode) Merge(r Router) (Router, error) {
+	node, ok := r.(*StringNode)
+	if !ok {
+		return nil, fmt.Errorf("unrecognized string router: %s", reflect.TypeOf(r).String())
+	}
+	commonPrefix := 0
+	for commonPrefix < len(n.Prefix) && commonPrefix < len(node.Prefix) {
+		if n.Prefix[commonPrefix] != node.Prefix[commonPrefix] {
+			break
+		}
+		commonPrefix++
+	}
+	if commonPrefix <= 0 {
+		return nil, fmt.Errorf("there is no common prefix for the two routers")
+	}
+	switch {
+	case commonPrefix == len(n.Prefix) && commonPrefix == len(node.Prefix):
+		n.Handler.Merge(&node.Handler)
+		n.Progeny.Merge(&node.Progeny)
+	case commonPrefix == len(n.Prefix):
+		node.Prefix = node.Prefix[commonPrefix:]
+		n.AddRouter(node)
+	case commonPrefix == len(node.Prefix):
+		copy := *n
+		copy.Prefix = copy.Prefix[commonPrefix:]
+		*n = *node
+		n.AddRouter(&copy)
+	default:
+		copy := *n
+		copy.Prefix = copy.Prefix[commonPrefix:]
+		node.Prefix = node.Prefix[commonPrefix:]
+		n.Handler = Handler{}
+		n.Progeny = Progeny{}
+		n.Prefix = n.Prefix[:commonPrefix]
+		n.AddRouter(&copy)
+		n.AddRouter(node)
+	}
+	return n, nil
+}


### PR DESCRIPTION
Implement regexp router.
- Support regexp router.
- Support Middleware.

```
Path examples:
/segments/segment/resources/resource
/segments/{segment}/resources/{resource}
/segments/{segment:[a-z]{1,2}}.log/resources/{resource}
/segments/{segment:[a-z]{1,2}}.log/resources/{resource}/{path:*}
/segments/{segment:[a-z]{1,2}}.log{temp:.*}sss/paths/{path:*}  
```

Performance:
```
goos: linux
goarch: amd64
pkg: github.com/kdada/go-http-routing-benchmark
BenchmarkNirvana_GithubStatic     	10000000	       119 ns/op	       0 B/op	       0 allocs/op
BenchmarkAce_GithubStatic         	20000000	        95.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkBear_GithubStatic        	 5000000	       328 ns/op	     120 B/op	       3 allocs/op
BenchmarkBeego_GithubStatic       	 1000000	      1130 ns/op	     352 B/op	       3 allocs/op
BenchmarkBone_GithubStatic        	  200000	      9363 ns/op	    2880 B/op	      60 allocs/op
BenchmarkDenco_GithubStatic       	50000000	        29.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkEcho_GithubStatic        	10000000	       171 ns/op	      32 B/op	       1 allocs/op
BenchmarkGin_GithubStatic         	20000000	        63.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkGocraftWeb_GithubStatic  	 3000000	       566 ns/op	     296 B/op	       5 allocs/op
BenchmarkGoji_GithubStatic        	10000000	       152 ns/op	       0 B/op	       0 allocs/op
BenchmarkGojiv2_GithubStatic      	 1000000	      2201 ns/op	    1312 B/op	      10 allocs/op
BenchmarkGoRestful_GithubStatic   	  100000	     11422 ns/op	    4392 B/op	      24 allocs/op
BenchmarkGoJsonRest_GithubStatic  	 2000000	       845 ns/op	     329 B/op	      11 allocs/op
BenchmarkGorillaMux_GithubStatic  	  200000	     11018 ns/op	     976 B/op	       9 allocs/op
BenchmarkHttpRouter_GithubStatic  	50000000	        34.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpTreeMux_GithubStatic 	30000000	        43.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkKocha_GithubStatic       	30000000	        48.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkLARS_GithubStatic        	20000000	        61.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkMacaron_GithubStatic     	 1000000	      1431 ns/op	     720 B/op	       8 allocs/op
BenchmarkMartini_GithubStatic     	  200000	     10475 ns/op	     768 B/op	       9 allocs/op
BenchmarkPat_GithubStatic         	  200000	     10474 ns/op	    3648 B/op	      76 allocs/op
BenchmarkPossum_GithubStatic      	 2000000	       671 ns/op	     416 B/op	       3 allocs/op
BenchmarkR2router_GithubStatic    	 5000000	       351 ns/op	     144 B/op	       4 allocs/op
BenchmarkRevel_GithubStatic       	 1000000	      3066 ns/op	    1408 B/op	      26 allocs/op
BenchmarkRivet_GithubStatic       	20000000	        74.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkTango_GithubStatic       	 2000000	       788 ns/op	     248 B/op	       8 allocs/op
BenchmarkTigerTonic_GithubStatic  	10000000	       184 ns/op	      48 B/op	       1 allocs/op
BenchmarkTraffic_GithubStatic     	   50000	     33813 ns/op	   22776 B/op	     166 allocs/op
BenchmarkVulcan_GithubStatic      	 2000000	       590 ns/op	      98 B/op	       3 allocs/op


BenchmarkNirvana_GithubParam      	10000000	       206 ns/op	       0 B/op	       0 allocs/op
BenchmarkAce_GithubParam          	 5000000	       239 ns/op	      96 B/op	       1 allocs/op
BenchmarkBear_GithubParam         	 2000000	       780 ns/op	     496 B/op	       5 allocs/op
BenchmarkBeego_GithubParam        	 2000000	       984 ns/op	     352 B/op	       3 allocs/op
BenchmarkBone_GithubParam         	  300000	      5095 ns/op	    1888 B/op	      19 allocs/op
BenchmarkDenco_GithubParam        	10000000	       231 ns/op	     128 B/op	       1 allocs/op
BenchmarkEcho_GithubParam         	10000000	       237 ns/op	      32 B/op	       1 allocs/op
BenchmarkGin_GithubParam          	20000000	       106 ns/op	       0 B/op	       0 allocs/op
BenchmarkGocraftWeb_GithubParam   	 1000000	      1091 ns/op	     712 B/op	       9 allocs/op
BenchmarkGoji_GithubParam         	 2000000	       740 ns/op	     336 B/op	       2 allocs/op
BenchmarkGojiv2_GithubParam       	 1000000	      1839 ns/op	    1408 B/op	      13 allocs/op
BenchmarkGoJsonRest_GithubParam   	 1000000	      1406 ns/op	     713 B/op	      14 allocs/op
BenchmarkGoRestful_GithubParam    	  200000	     11469 ns/op	    2824 B/op	      22 allocs/op
BenchmarkGorillaMux_GithubParam   	  200000	      6669 ns/op	    1296 B/op	      10 allocs/op
BenchmarkHttpRouter_GithubParam   	10000000	       172 ns/op	      96 B/op	       1 allocs/op
BenchmarkHttpTreeMux_GithubParam  	 2000000	       648 ns/op	     384 B/op	       4 allocs/op
BenchmarkKocha_GithubParam        	 5000000	       382 ns/op	     128 B/op	       5 allocs/op
BenchmarkLARS_GithubParam         	20000000	        96.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkMacaron_GithubParam      	 1000000	      1828 ns/op	    1056 B/op	      10 allocs/op
BenchmarkMartini_GithubParam      	  200000	      7998 ns/op	    1152 B/op	      11 allocs/op
BenchmarkPat_GithubParam          	  200000	      7300 ns/op	    2464 B/op	      48 allocs/op
BenchmarkPossum_GithubParam       	 2000000	       875 ns/op	     544 B/op	       5 allocs/op
BenchmarkR2router_GithubParam     	 2000000	       623 ns/op	     432 B/op	       5 allocs/op
BenchmarkRevel_GithubParam        	  500000	      3871 ns/op	    1904 B/op	      31 allocs/op
BenchmarkRivet_GithubParam        	 5000000	       277 ns/op	      96 B/op	       1 allocs/op
BenchmarkTango_GithubParam        	 1000000	      1173 ns/op	     472 B/op	      11 allocs/op
BenchmarkTigerTonic_GithubParam   	  500000	      2983 ns/op	    1440 B/op	      24 allocs/op
BenchmarkTraffic_GithubParam      	  200000	     11505 ns/op	    6952 B/op	      56 allocs/op
BenchmarkVulcan_GithubParam       	 2000000	       902 ns/op	      98 B/op	       3 allocs/op


BenchmarkNirvana_GithubAll        	   30000	     43178 ns/op	       0 B/op	       0 allocs/op
BenchmarkAce_GithubAll            	   30000	     47501 ns/op	   13792 B/op	     167 allocs/op
BenchmarkBear_GithubAll           	   10000	    155288 ns/op	   86448 B/op	     943 allocs/op
BenchmarkBeego_GithubAll          	   10000	    198875 ns/op	   71456 B/op	     609 allocs/op
BenchmarkBone_GithubAll           	    1000	   2007746 ns/op	  720160 B/op	    8620 allocs/op
BenchmarkDenco_GithubAll          	   30000	     44171 ns/op	   20224 B/op	     167 allocs/op
BenchmarkEcho_GithubAll           	   30000	     48986 ns/op	    6496 B/op	     203 allocs/op
BenchmarkGin_GithubAll            	  100000	     20937 ns/op	       0 B/op	       0 allocs/op
BenchmarkGocraftWeb_GithubAll     	   10000	    212242 ns/op	  131656 B/op	    1686 allocs/op
BenchmarkGoji_GithubAll           	    5000	    316694 ns/op	   56112 B/op	     334 allocs/op
BenchmarkGojiv2_GithubAll         	    3000	    555556 ns/op	  352720 B/op	    4321 allocs/op
BenchmarkGoJsonRest_GithubAll     	   10000	    280764 ns/op	  134371 B/op	    2737 allocs/op
BenchmarkGoRestful_GithubAll      	    1000	   2469835 ns/op	  912696 B/op	    4868 allocs/op
BenchmarkGorillaMux_GithubAll     	     300	   4007698 ns/op	  251648 B/op	    1994 allocs/op
BenchmarkHttpRouter_GithubAll     	   50000	     31013 ns/op	   13792 B/op	     167 allocs/op
BenchmarkHttpTreeMux_GithubAll    	   10000	    118069 ns/op	   65856 B/op	     671 allocs/op
BenchmarkKocha_GithubAll          	   20000	     77520 ns/op	   23304 B/op	     843 allocs/op
BenchmarkLARS_GithubAll           	  100000	     19292 ns/op	       0 B/op	       0 allocs/op
BenchmarkMacaron_GithubAll        	   10000	    287076 ns/op	  146161 B/op	    1624 allocs/op
BenchmarkMartini_GithubAll        	     500	   3335191 ns/op	  226547 B/op	    2325 allocs/op
BenchmarkPat_GithubAll            	     500	   3283946 ns/op	 1499568 B/op	   27435 allocs/op
BenchmarkPossum_GithubAll         	   10000	    129200 ns/op	   84448 B/op	     609 allocs/op
BenchmarkR2router_GithubAll       	   10000	    117080 ns/op	   77328 B/op	     979 allocs/op
BenchmarkRevel_GithubAll          	    2000	    720247 ns/op	  369920 B/op	    6121 allocs/op
BenchmarkRivet_GithubAll          	   30000	     53120 ns/op	   16272 B/op	     167 allocs/op
BenchmarkTango_GithubAll          	   10000	    202611 ns/op	   85451 B/op	    2064 allocs/op
BenchmarkTigerTonic_GithubAll     	    2000	    560224 ns/op	  239104 B/op	    5374 allocs/op
BenchmarkTraffic_GithubAll        	     300	   5195233 ns/op	 3097761 B/op	   23742 allocs/op
BenchmarkVulcan_GithubAll         	   10000	    151446 ns/op	   19894 B/op	     609 allocs/op
```