### PR TITLE
fix(router): ignore empty string segment in splitting

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -194,7 +194,9 @@ func Split(path string) ([]string, error) {
 		case '{':
 			braceCounter++
 			if braceCounter == 1 {
-				result = append(result, path[lastElementPos:i])
+				if i > lastElementPos {
+					result = append(result, path[lastElementPos:i])
+				}
 				lastElementPos = i
 			}
 		case '}':


### PR DESCRIPTION
<!-- PR template; please answer the questions. -->

**What this PR does**
`Split` creates a useless empty string segment when there is nothing before char '{'. It's a bug.

