### PR TITLE
feat(service): let consumers and producers support string and []byte

### DIFF
--- a/service/content_test.go
+++ b/service/content_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2018 Caicloud Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/caicloud/nirvana/definition"
+)
+
+type vc2 struct {
+	vc
+	contentType string
+	data        string
+}
+
+func (v *vc2) Body() (reader io.ReadCloser, contentType string, ok bool) {
+	return &file{[]byte(v.data), 0}, v.contentType, true
+}
+
+func TestConsumer(t *testing.T) {
+	const data = `{"value":"test body"}`
+	types := []string{
+		definition.MIMEText,
+		definition.MIMEJSON,
+		definition.MIMEXML,
+		definition.MIMEOctetStream,
+		definition.MIMEURLEncoded,
+		definition.MIMEFormData,
+	}
+	targets := []reflect.Type{
+		reflect.TypeOf(""),
+		reflect.TypeOf(([]byte)(nil)),
+	}
+	defaults := []interface{}{
+		"",
+		[]byte{},
+	}
+	g := &BodyParameterGenerator{}
+	for _, ct := range types {
+		for i, target := range targets {
+			def := defaults[i]
+			if err := g.Validate("test", def, target); err != nil {
+				t.Fatal(err)
+			}
+			result, err := g.Generate(
+				context.Background(),
+				&vc2{
+					contentType: ct,
+					data:        data,
+				},
+				AllConsumers(),
+				"test",
+				target,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch r := result.(type) {
+			case string:
+				if r != data {
+					t.Fatalf("Generate wrong data: %v", r)
+				}
+			case []byte:
+				if string(r) != data {
+					t.Fatalf("Generate wrong data: %v", r)
+				}
+			}
+		}
+	}
+
+}
+
+func TestProducer(t *testing.T) {
+	const data = `{"value":"test body"}`
+	types := []string{
+		definition.MIMEText,
+		definition.MIMEJSON,
+		definition.MIMEXML,
+		definition.MIMEOctetStream,
+	}
+	values := []interface{}{
+		data,
+		[]byte(data),
+	}
+	for _, at := range types {
+		producer := ProducerFor(at)
+		if producer == nil {
+			t.Fatalf("Can't find producer for accept type: %s", at)
+		}
+		for _, v := range values {
+			w := bytes.NewBuffer(nil)
+			if err := producer.Produce(w, v); err != nil {
+				t.Fatal(err)
+			}
+			if data != w.String() {
+				t.Fatalf("Producer %s writed wrong data: %s", at, w.Bytes())
+			}
+		}
+	}
+}

--- a/service/source.go
+++ b/service/source.go
@@ -247,6 +247,7 @@ func (g *BodyParameterGenerator) Validate(name string, defaultValue interface{},
 	}
 	kind := target.Kind()
 	switch {
+	case kind == reflect.String:
 	case kind == reflect.Slice:
 	case kind == reflect.Struct:
 	case kind == reflect.Ptr && target.Elem().Kind() == reflect.Struct:
@@ -295,10 +296,11 @@ func (g *BodyParameterGenerator) Generate(ctx context.Context, vc ValueContainer
 		return nil, nil
 	}
 	var value reflect.Value
+	// Create a pointer to target.
+	// Value is a pointer and it points to nil.
+	// consumer should fill it.
 	switch {
-	case kind == reflect.Slice:
-		value = reflect.MakeSlice(target, 0, 10)
-	case kind == reflect.Struct:
+	case kind == reflect.String || kind == reflect.Slice || kind == reflect.Struct:
 		value = reflect.New(target)
 	case kind == reflect.Ptr && target.Elem().Kind() == reflect.Struct:
 		value = reflect.New(target.Elem())
@@ -308,7 +310,7 @@ func (g *BodyParameterGenerator) Generate(ctx context.Context, vc ValueContainer
 	if err := consumer.Consume(reader, value.Interface()); err != nil {
 		return nil, err
 	}
-	if kind == reflect.Struct {
+	if kind == reflect.String || kind == reflect.Slice || kind == reflect.Struct {
 		return value.Elem().Interface(), nil
 	}
 	return value.Interface(), nil

--- a/service/utils.go
+++ b/service/utils.go
@@ -83,3 +83,7 @@ var invalidAutoParameter = errors.InternalServerError.Build("Nirvana:Service:Inv
 var noParameterGenerator = errors.InternalServerError.Build("Nirvana:Service:NoParameterGenerator", "no parameter generator for source ${source}")
 var invalidFieldTag = errors.InternalServerError.Build("Nirvana:Service:InvalidFieldTag", "filed tag ${tag} is invalid")
 var noName = errors.InternalServerError.Build("Nirvana:Service:NoName", "${source} must have a name")
+var invalidTypeForConsumer = errors.InternalServerError.Build("Nirvana:Service:InvalidTypeForConsumer",
+	"consumer ${content} can't consume data for type ${type}")
+var invalidTypeForProducer = errors.InternalServerError.Build("Nirvana:Service:InvalidTypeForProducer",
+	"producer ${content} can't produce data for type ${type}")


### PR DESCRIPTION
<!-- PR template; please answer the questions. -->

**What this PR does**
Now, Type `string` and `[]byte` can be used to receive data from http body.

**why we need it**
In some occasion, we just want get body string rather than a struct.

**Release note**
```release-note
Let consumers and producers support string and []byte.
```