### PR TITLE
fix(context): canonical format of the MIME header key

### DIFF
--- a/service/context.go
+++ b/service/context.go
@@ -23,6 +23,7 @@ import (
 	"mime/multipart"
 	"net"
 	"net/http"
+	"net/textproto"
 	"net/url"
 )
 
@@ -139,7 +140,7 @@ func (c *container) Query(key string) ([]string, bool) {
 
 // Header returns value by header key.
 func (c *container) Header(key string) ([]string, bool) {
-	h := c.request.Header[key]
+	h := c.request.Header[textproto.CanonicalMIMEHeaderKey(key)]
 	return h, len(h) > 0
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The canonical key for "accept-encoding" is "Accept-Encoding".

**Special notes for your reviewer**:
/assign @kdada 

```release-note
NONE
```