### PR TITLE
fix(errors): support to marshal errors into XML

### DIFF
--- a/errors/kinds.go
+++ b/errors/kinds.go
@@ -40,7 +40,7 @@ func (t kind) Build(reason Reason, format string) Factory {
 
 // Error immediately creates an error without reason.
 func (t kind) Error(format string, v ...interface{}) error {
-	msg, data := expand(format, v)
+	msg, data := expand(format, v...)
 	return &err{
 		message: message{
 			Message: msg,

--- a/service/content.go
+++ b/service/content.go
@@ -254,7 +254,11 @@ func (s *JSONSerializer) Consume(r io.Reader, v interface{}) error {
 	case *[]byte:
 		return s.consume(s.ContentType(), r, v)
 	}
-	return json.NewDecoder(r).Decode(v)
+	err := json.NewDecoder(r).Decode(v)
+	if err == io.EOF {
+		return nil
+	}
+	return err
 }
 
 // Produce marshals v to json and write to w.
@@ -284,7 +288,11 @@ func (s *XMLSerializer) Consume(r io.Reader, v interface{}) error {
 	case *[]byte:
 		return s.consume(s.ContentType(), r, v)
 	}
-	return xml.NewDecoder(r).Decode(v)
+	err := xml.NewDecoder(r).Decode(v)
+	if err == io.EOF {
+		return nil
+	}
+	return err
 }
 
 // Produce marshals v to xml and write to w.


### PR DESCRIPTION
<!-- PR template; please answer the questions. -->

**What this PR does / why we need it**:
Support to marshal errors into XML. Standard XML package does not support map. Wrap the map and implement `MarshalXML`.

**Special notes for your reviewer**:
/assign @yejiayu 
/area framework
/kind bug
/priority p0

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```