### PR TITLE
feat(tracing): Set global tracer

### DIFF
--- a/plugins/tracing/tracing.go
+++ b/plugins/tracing/tracing.go
@@ -113,6 +113,7 @@ func wapper(c *nirvana.Config, f func(c *config)) {
 		cfg = conf.(*config)
 	}
 	f(cfg)
+	opentracing.SetGlobalTracer(cfg.tracer)
 	c.Set(ExternalConfigName, cfg)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Set a global tracer  to direct call `opentracing. StartSpanFromContext`
**Which issue(s) this PR fixes** :
**Special notes for your reviewer**:
/assign kdada

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```