### PR TITLE
feat(builder): validate operators at startup time

### DIFF
--- a/definition/helper.go
+++ b/definition/helper.go
@@ -196,7 +196,8 @@ func ErrorResult() Result {
 
 // OperatorFunc creates operator by function.
 // function must has signature:
-//  func f(context.Context, AnyType) (AnyType, error)
+//  func f(context.Context, string, AnyType) (AnyType, error)
+// The second parameter is a string that is used to identify field.
 // AnyType can be any type in go. But struct type and
 // built-in data type is recommended.
 func OperatorFunc(kind string, f interface{}) Operator {

--- a/nirvana.go
+++ b/nirvana.go
@@ -95,7 +95,7 @@ func (c *Config) forEach(f func(name string, config interface{}) error) error {
 // Default config contains:
 //  Filters: RedirectTrailingSlash, FillLeadingSlash, ParseRequestForm.
 //  Modifiers: FirstContextParameter, EmptyConsumeForHTTPGet,
-//             ConsumeAllIfComsumesIsEmpty, ProduceAllIfProducesIsEmpty,
+//             ConsumeAllIfConsumesIsEmpty, ProduceAllIfProducesIsEmpty,
 //             ConsumeNoneForHTTPGet, ConsumeNoneForHTTPDelete,
 //             ProduceNoneForHTTPDelete.
 func NewDefaultConfig(ip string, port uint16) *Config {
@@ -110,7 +110,7 @@ func NewDefaultConfig(ip string, port uint16) *Config {
 		),
 		Modifier(
 			service.FirstContextParameter(),
-			service.ConsumeAllIfComsumesIsEmpty(),
+			service.ConsumeAllIfConsumesIsEmpty(),
 			service.ProduceAllIfProducesIsEmpty(),
 			service.ConsumeNoneForHTTPGet(),
 			service.ConsumeNoneForHTTPDelete(),

--- a/service/executor.go
+++ b/service/executor.go
@@ -50,7 +50,7 @@ func (i *inspector) addDefinition(d definition.Definition) error {
 		return definitionNoMethod.Error(d.Method, i.path)
 	}
 	if len(d.Consumes) <= 0 {
-		return definitionNoComsumes.Error(d.Method, i.path)
+		return definitionNoConsumes.Error(d.Method, i.path)
 	}
 	if len(d.Produces) <= 0 {
 		return definitionNoProduces.Error(d.Method, i.path)
@@ -79,7 +79,7 @@ func (i *inspector) addDefinition(d definition.Definition) error {
 			c.consumers = append(c.consumers, consumer)
 			consumes[consumer.ContentType()] = true
 		} else {
-			return definitionNoComsumer.Error(ct, d.Method, i.path)
+			return definitionNoConsumer.Error(ct, d.Method, i.path)
 		}
 	}
 	if consumeAll {

--- a/service/executor.go
+++ b/service/executor.go
@@ -189,6 +189,12 @@ func (i *inspector) generateParameters(funcName string, typ reflect.Type, ps []d
 			i.logger.Errorf("Can't validate %s parameter of function %s: %s", order(index+1), funcName, err.Error())
 			return nil, err
 		}
+		if len(param.operators) > 0 {
+			if err := i.validateOperators(param.targetType, typ.In(index), param.operators); err != nil {
+				i.logger.Errorf("Can't validate operators for %s parameter of function %s: %s", order(index+1), funcName, err.Error())
+				return nil, err
+			}
+		}
 		parameters = append(parameters, param)
 	}
 	return parameters, nil
@@ -202,14 +208,23 @@ func (i *inspector) generateResults(funcName string, typ reflect.Type, rs []defi
 	for index, r := range rs {
 		handler := DestinationHandlerFor(r.Destination)
 		if handler == nil {
-			return nil, noDestinationHandler.Error(r.Description)
+			return nil, noDestinationHandler.Error(r.Destination)
 		}
 		result := result{
 			index:     index,
 			handler:   handler,
 			operators: r.Operators,
 		}
-		if err := handler.Validate(typ.Out(index)); err != nil {
+		outType := typ.Out(index)
+		if len(result.operators) > 0 {
+			LastOperatorOutType := result.operators[len(result.operators)-1].Out()
+			if err := i.validateOperators(outType, LastOperatorOutType, result.operators); err != nil {
+				i.logger.Errorf("Can't validate operators for %s result of function %s: %s", order(index+1), funcName, err.Error())
+				return nil, err
+			}
+			outType = LastOperatorOutType
+		}
+		if err := handler.Validate(outType); err != nil {
 			// Order from 0 is odd. So index+1.
 			i.logger.Errorf("Can't validate %s result of function %s: %s", order(index+1), funcName, err.Error())
 			return nil, err
@@ -219,6 +234,32 @@ func (i *inspector) generateResults(funcName string, typ reflect.Type, rs []defi
 	sort.Sort(resultsSorter(results))
 	return results, nil
 
+}
+
+// validateOperators checks if the chain is valid:
+//   in -> operators[0].In()
+//   operators[0].Out() -> operators[1].In()
+//   ...
+//   operators[N].Out() -> out
+func (i *inspector) validateOperators(in, out reflect.Type, operators []definition.Operator) error {
+	if len(operators) <= 0 {
+		return nil
+	}
+	index := 0
+	for ; index < len(operators); index++ {
+		operator := operators[index]
+		if !in.AssignableTo(operator.In()) {
+			// The out type of operator[index-1] is not compatible to operator[index].
+			return invalidOperatorInType.Error(in, order(index+1))
+		}
+		in = operator.Out()
+	}
+	typ := operators[index-1].Out()
+	if !typ.AssignableTo(out) {
+		// The last operator is not compatible to out type.
+		return invalidOperatorOutType.Error(order(index), out)
+	}
+	return nil
 }
 
 type resultsSorter []result

--- a/service/executor_test.go
+++ b/service/executor_test.go
@@ -1,0 +1,287 @@
+/*
+Copyright 2018 Caicloud Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/caicloud/nirvana/definition"
+	"github.com/caicloud/nirvana/errors"
+	"github.com/caicloud/nirvana/log"
+)
+
+type definitionMap struct {
+	def definition.Definition
+	err errors.Factory
+}
+
+func TestAddDefinition(t *testing.T) {
+	inspector := newInspector("/test", &log.SilentLogger{})
+	units := []definitionMap{
+		{
+			definition.Definition{
+				Method: definition.Method(""),
+			},
+			definitionNoMethod,
+		},
+		{
+			definition.Definition{
+				Method: definition.Get,
+			},
+			definitionNoComsumes,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+			},
+			definitionNoProduces,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+				Produces: []string{definition.MIMEJSON},
+			},
+			definitionNoFunction,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+				Produces: []string{definition.MIMEJSON},
+				Function: 1,
+			},
+			definitionInvalidFunctionType,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{"invalid-content-type"},
+				Produces: []string{definition.MIMEJSON},
+				Function: func() {
+				},
+			},
+			definitionNoComsumer,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+				Produces: []string{"invalid-content-type"},
+				Function: func() {
+				},
+			},
+			definitionNoProducer,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+				Produces: []string{"invalid-content-type"},
+				Function: func() {
+				},
+			},
+			definitionNoProducer,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+				Produces: []string{definition.MIMEJSON},
+				Function: func(ctx context.Context) {
+				},
+			},
+			definitionUnmatchedParameters,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+				Produces: []string{definition.MIMEJSON},
+				Parameters: []definition.Parameter{
+					{
+						Source: "InvalidSource",
+					},
+				},
+				Function: func(a int) {
+				},
+			},
+			noParameterGenerator,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+				Produces: []string{definition.MIMEJSON},
+				Parameters: []definition.Parameter{
+					{
+						Source:  definition.Path,
+						Name:    "a",
+						Default: "InvalidDefaultValue",
+					},
+				},
+				Function: func(a int) {
+				},
+			},
+			unassignableType,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+				Produces: []string{definition.MIMEJSON},
+				Parameters: []definition.Parameter{
+					{
+						Source: definition.Path,
+						Name:   "a",
+					},
+				},
+				Function: func(a []int) {
+				},
+			},
+			noConverter,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+				Produces: []string{definition.MIMEJSON},
+				Parameters: []definition.Parameter{
+					{
+						Source: definition.Query,
+						Name:   "a",
+						Operators: []definition.Operator{
+							definition.OperatorFunc("test", func(ctx context.Context, key string, value string) (int, error) {
+								return 1, nil
+							}),
+						},
+					},
+				},
+				Function: func(a []int) {
+				},
+			},
+			invalidOperatorOutType,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+				Produces: []string{definition.MIMEJSON},
+				Parameters: []definition.Parameter{
+					{
+						Source: definition.Query,
+						Name:   "a",
+						Operators: []definition.Operator{
+							definition.OperatorFunc("test", func(ctx context.Context, key string, value string) (int, error) {
+								return 1, nil
+							}),
+							definition.OperatorFunc("test", func(ctx context.Context, key string, value string) ([]int, error) {
+								return []int{1}, nil
+							}),
+						},
+					},
+				},
+				Function: func(a []int) {
+				},
+			},
+			invalidOperatorInType,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+				Produces: []string{definition.MIMEJSON},
+				Function: func() int {
+					return 0
+				},
+			},
+			definitionUnmatchedResults,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+				Produces: []string{definition.MIMEJSON},
+				Results: []definition.Result{
+					{
+						Destination: definition.Destination("InvalidDestination"),
+					},
+				},
+				Function: func() int {
+					return 0
+				},
+			},
+			noDestinationHandler,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+				Produces: []string{definition.MIMEJSON},
+				Results: []definition.Result{
+					{
+						Destination: definition.Data,
+						Operators: []definition.Operator{
+							definition.OperatorFunc("test", func(ctx context.Context, key string, value string) (int, error) {
+								return 1, nil
+							}),
+						},
+					},
+				},
+				Function: func() int {
+					return 0
+				},
+			},
+			invalidOperatorInType,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+				Produces: []string{definition.MIMEJSON},
+				Function: func() {
+				},
+			},
+			nil,
+		},
+		{
+			definition.Definition{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+				Produces: []string{definition.MIMEXML},
+				Function: func() {
+				},
+			},
+			definitionConflict,
+		},
+	}
+
+	for _, unit := range units {
+		err := inspector.addDefinition(unit.def)
+		if unit.err != nil {
+			if err == nil {
+				t.Errorf("Expected error but got nil for %+v", unit.def)
+			} else if !unit.err.Derived(err) {
+				t.Fatalf("Unexpected err: %v for %+v", err, unit.def)
+			}
+		} else if err != nil {
+			t.Fatalf("Unexpected err: %v for %+v", err, unit.def)
+		}
+	}
+}

--- a/service/executor_test.go
+++ b/service/executor_test.go
@@ -43,7 +43,7 @@ func TestAddDefinition(t *testing.T) {
 			definition.Definition{
 				Method: definition.Get,
 			},
-			definitionNoComsumes,
+			definitionNoConsumes,
 		},
 		{
 			definition.Definition{
@@ -77,7 +77,7 @@ func TestAddDefinition(t *testing.T) {
 				Function: func() {
 				},
 			},
-			definitionNoComsumer,
+			definitionNoConsumer,
 		},
 		{
 			definition.Definition{

--- a/service/modifier.go
+++ b/service/modifier.go
@@ -59,9 +59,9 @@ func FirstContextParameter() DefinitionModifier {
 	}
 }
 
-// ConsumeAllIfComsumesIsEmpty adds definition.MIMEAll to consumes if consumes
+// ConsumeAllIfConsumesIsEmpty adds definition.MIMEAll to consumes if consumes
 // is empty.
-func ConsumeAllIfComsumesIsEmpty() DefinitionModifier {
+func ConsumeAllIfConsumesIsEmpty() DefinitionModifier {
 	return func(d *definition.Definition) {
 		if len(d.Consumes) <= 0 {
 			d.Consumes = []string{definition.MIMEAll}

--- a/service/utils.go
+++ b/service/utils.go
@@ -87,3 +87,7 @@ var invalidTypeForConsumer = errors.InternalServerError.Build("Nirvana:Service:I
 	"consumer ${content} can't consume data for type ${type}")
 var invalidTypeForProducer = errors.InternalServerError.Build("Nirvana:Service:InvalidTypeForProducer",
 	"producer ${content} can't produce data for type ${type}")
+var invalidOperatorInType = errors.InternalServerError.Build("Nirvana:Service:InvalidOperatorInType",
+	"the type ${type} is not compatible to the in type of the ${index} operator")
+var invalidOperatorOutType = errors.InternalServerError.Build("Nirvana:Service:InvalidOperatorOutType",
+	"the out type of the ${index} operator is not compatible to the type ${type}")

--- a/service/utils.go
+++ b/service/utils.go
@@ -53,12 +53,12 @@ var invalidProducer = errors.InternalServerError.Build("Nirvana:Service:InvalidP
 var noConnectionHijacker = errors.InternalServerError.Build("Nirvana:Service:NoConnectionHijacker",
 	"underlying http.ResponseWriter does not implement http.Hijacker")
 var definitionNoMethod = errors.InternalServerError.Build("Nirvana:Service:DefinitionNoMethod", "no http method in [${method}]${path}")
-var definitionNoComsumes = errors.InternalServerError.Build("Nirvana:Service:DefinitionNoComsumes", "no content type to consume in [${method}]${path}")
+var definitionNoConsumes = errors.InternalServerError.Build("Nirvana:Service:DefinitionNoConsumes", "no content type to consume in [${method}]${path}")
 var definitionNoProduces = errors.InternalServerError.Build("Nirvana:Service:DefinitionNoProduces", "no content type to produce in [${method}]${path}")
 var definitionNoFunction = errors.InternalServerError.Build("Nirvana:Service:DefinitionNoFunction", "no function in [${method}]${path}")
 var definitionInvalidFunctionType = errors.InternalServerError.Build("Nirvana:Service:DefinitionInvalidFunctionType",
 	"${type} is not function in [${method}]${path}")
-var definitionNoComsumer = errors.InternalServerError.Build("Nirvana:Service:DefinitionNoComsumer",
+var definitionNoConsumer = errors.InternalServerError.Build("Nirvana:Service:DefinitionNoConsumer",
 	"no consumer for content type ${type} in [${method}]${path}")
 var definitionNoProducer = errors.InternalServerError.Build("Nirvana:Service:DefinitionNoProducer",
 	"no producer for content type ${type} in [${method}]${path}")


### PR DESCRIPTION
<!-- PR template; please answer the questions. -->

**What this PR does / why we need it**:
For an operator chain:
```
in -> operators[0].In()
operators[0].Out() -> operators[1].In()
...
operators[N].Out() -> out
```
Parameter types and result types are checked at startup time now.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #73 

**Special notes for your reviewer**:
/assign @yejiayu 
/assign @Jimexist 
/area framwork
/kind enhancement
/priority P1

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Check parameters and results of operators at startup time
```