### PR TITLE
feat(service): support plain error message for TextSerializer and OctetStreamSerializer

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -85,6 +85,11 @@ type message struct {
 	Data dataMap `json:"data,omitempty" xml:",omitempty"`
 }
 
+// Error returns error description.
+func (m *message) Error() string {
+	return m.Message
+}
+
 // err implements error interface.
 type err struct {
 	message
@@ -98,7 +103,7 @@ func (e *err) Code() int {
 
 // Message returns detailed message of the error.
 func (e *err) Message() interface{} {
-	return e.message
+	return &e.message
 }
 
 // Error returns error description.

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -132,7 +132,7 @@ func TestNewRaw(t *testing.T) {
 	err := NewFactory(400, "japari:NotFriend", "${kind} is not in japari park").Error("anje").(*err)
 	if err.Error() != "anje is not in japari park" ||
 		err.Code() != 400 ||
-		!reflect.DeepEqual(err.Message(), message{
+		!reflect.DeepEqual(err.Message(), &message{
 			Reason: "japari:NotFriend",
 			Data: map[string]string{
 				"kind": "anje",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

- Implement method Error for message
- Support plain error message for TextSerializer and OctetStreamSerializer

**Which issue(s) this PR fixes** *(optional, close the issue(s) when PR gets merged)*:

Fixes #128

**Special notes for your reviewer**:

/assign @ddysher 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Support plain error message for TextSerializer and OctetStreamSerializer
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
