### PR TITLE
fix(metrics): histogram should collect latencies for milliseconds 

### DIFF
--- a/examples/instrumentation/main.go
+++ b/examples/instrumentation/main.go
@@ -29,8 +29,10 @@ import (
 )
 
 // This example shows how metrics and profiling plugin work, and the defaults functionality they provide.
-// Run `ab -n 100 -H 'Content-type: application/json' http://localhost:8080/hello`, then
+// Run `ab -n 1000 http://localhost:8080/hello`, then
 // curl `http://localhost:8080/metrics` to see default metrics for http requests.
+// Use following prometheus query to see 95th percentile:
+// histogram_quantile (0.95, sum(rate(nirvana_request_latencies_bucket{path="/hello"}[5m])) by (le))
 func main() {
 	config := nirvana.NewDefaultConfig("", 8080).
 		Configure(
@@ -55,7 +57,7 @@ var example = definition.Descriptor{
 		{
 			Method: definition.Get,
 			Function: func(ctx context.Context) (string, error) {
-				latency := 20 + rand.Float64()*300
+				latency := rand.NormFloat64()*7.5 + 10
 				<-time.After(time.Duration(latency) * time.Millisecond)
 				return "success", nil
 			},

--- a/plugins/metrics/metrics.go
+++ b/plugins/metrics/metrics.go
@@ -57,8 +57,8 @@ func newMetricsMiddleware(namespace string) definition.Middleware {
 		prometheus.HistogramOpts{
 			Namespace: namespace,
 			Name:      "request_latencies",
-			Help:      "Response latency distribution in microseconds for each verb, resource and client.",
-			Buckets:   prometheus.ExponentialBuckets(125000, 2.0, 7),
+			Help:      "Response latency distribution in milliseconds for each verb, resource and client.",
+			Buckets:   prometheus.ExponentialBuckets(0.1, 2.0, 20),
 		},
 		[]string{"method", "path"},
 	)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Use milliseconds instead of microseconds

**Which issue(s) this PR fixes** *(optional, close the issue(s) when PR gets merged)*:

Fixes #

**Special notes for your reviewer**:

/cc @your-reviewer

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
