### PR TITLE
fix(service): remove cache pool for http context

### DIFF
--- a/service/context.go
+++ b/service/context.go
@@ -42,32 +42,13 @@ type httpCtx struct {
 	path      string
 }
 
-func newHTTPContext() interface{} {
+func newHTTPContext(resp http.ResponseWriter, request *http.Request) *httpCtx {
 	ctx := &httpCtx{}
+	ctx.Context = request.Context()
+	ctx.container.request = request
 	ctx.container.params = make([]param, 0, 5)
+	ctx.response.writer = resp
 	return ctx
-}
-
-// reset resets itself by a http.Request and a http.ResponseWriter.
-func (c *httpCtx) reset(w http.ResponseWriter, request *http.Request) {
-	// Get context from request.
-	c.Context = request.Context()
-	// Reset value container.
-	c.container.request = request
-	c.container.params = c.container.params[:0]
-	c.container.query = nil
-	// Reset response.
-	c.response.writer = w
-	c.response.statusCode = 0
-	c.response.contentLength = 0
-}
-
-// clear clears request and response.
-func (c *httpCtx) clear() {
-	c.Context = nil
-	c.container.request = nil
-	c.container.query = nil
-	c.response.writer = nil
 }
 
 // Value returns itself when key is contextKeyUnderlyingHTTPContext.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

We have a cache pool for HTTP context before. It creates new context when a request coming and recycles it after the request done. But if someone use this context after it being recycled, it may panic. 
There are two ways we have considered:
1. Add a safe layer for the context
  - Flexible
  - Still has a problem about retained HTTPContext.
    ```go
    func handler(ctx context.Context) {
        // The retained httpCtx may go in wrong after the context being recycled.
        httpCtx := service.HTTPContextFrom(ctx)
    }
    ```
1. Remove cache pool
  - Simple
  - Has minimal performance loss (about 1%).

So we choose the second solution. 

**Special notes for your reviewer**:

/cc @ddysher 
/cc @caitong93 
/cc @walktall 
/cc @zoumo 
/cc @Jimexist 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Remove cache pool for http context
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
