### PR TITLE
feat(config): add PreConfigure and PostConfigure hooks

### DIFF
--- a/config/hooks.go
+++ b/config/hooks.go
@@ -22,6 +22,10 @@ import (
 
 // NirvanaCommandHook provides several hook points for NirvanaCommand.
 type NirvanaCommandHook interface {
+	// PreConfigure runs before installing plugins.
+	PreConfigure(config *nirvana.Config) error
+	// PostConfigure runs after installing plugins and before creating nirvana server.
+	PostConfigure(config *nirvana.Config) error
 	// PreServe runs before nirvana server serving.
 	PreServe(config *nirvana.Config, server nirvana.Server) error
 	// PostServe runs after nirvana server shutting down or any error occurring.
@@ -31,8 +35,26 @@ type NirvanaCommandHook interface {
 // NirvanaCommandHookFunc is a helper to generate NirvanaCommandHook. Hook points
 // are optional.
 type NirvanaCommandHookFunc struct {
-	PreServeFunc  func(config *nirvana.Config, server nirvana.Server) error
-	PostServeFunc func(config *nirvana.Config, server nirvana.Server, err error) error
+	PreConfigureFunc  func(config *nirvana.Config) error
+	PostConfigureFunc func(config *nirvana.Config) error
+	PreServeFunc      func(config *nirvana.Config, server nirvana.Server) error
+	PostServeFunc     func(config *nirvana.Config, server nirvana.Server, err error) error
+}
+
+// PreConfigure runs before installing plugins.
+func (h *NirvanaCommandHookFunc) PreConfigure(config *nirvana.Config) error {
+	if h.PreConfigureFunc != nil {
+		return h.PreConfigure(config)
+	}
+	return nil
+}
+
+// PostConfigure runs after installing plugins and before creating nirvana server.
+func (h *NirvanaCommandHookFunc) PostConfigure(config *nirvana.Config) error {
+	if h.PostConfigureFunc != nil {
+		return h.PostConfigureFunc(config)
+	}
+	return nil
 }
 
 // PreServe runs before nirvana server serving.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add PreConfigure and PostConfigure hooks.
After creating nirvana server, config becomes immutable. So we need the two hooks.

**Which issue(s) this PR fixes** *(optional, close the issue(s) when PR gets merged)*:

Fixes #

**Special notes for your reviewer**:

/cc @caitong93 
/cc @zoumo 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Add PreConfigure and PostConfigure hooks
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
