### PR TITLE
fix(log): skip err check in std logger

### DIFF
--- a/log/std.go
+++ b/log/std.go
@@ -168,7 +168,9 @@ func (l *stdLogger) write(data string) {
 	if data[len(data)-1] != '\n' {
 		data += "\n"
 	}
-	fmt.Fprint(l.stream, data)
+	_, err := fmt.Fprint(l.stream, data)
+	// Ignore output error.
+	_ = err
 }
 
 func prefix(severity Severity, depth int) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

This PR is for skipping err check:
```
$ gometalinter --config=config.json ./...
log/std.go:171:12:warning: error return value not checked (fmt.Fprint(l.stream, data)) (errcheck)
```

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭，caicloud/quality 请用这个。-->

**Special notes for your reviewer**:

/cc @zjj2wry 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
