### PR TITLE
bugfix: correct resp should not return an err

### DIFF
--- a/rest/rest.go
+++ b/rest/rest.go
@@ -405,8 +405,9 @@ func (r *Request) finish(ctx context.Context, req *http.Request, resp *http.Resp
 					if err := xml.NewDecoder(reader).Decode(r.data); err != nil {
 						return unreadableBody.Error(r.path.String(), err.Error())
 					}
+				default:
+					return unrecognizedBody.Error(r.path.String(), "no appropriate receiver")
 				}
-				return unrecognizedBody.Error(r.path.String(), "no appropriate receiver")
 			}
 		}
 	} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

correct resp should not return an err


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```