### PR TITLE
fix: init cmd path error on windows.

### DIFF
--- a/utils/project/path.go
+++ b/utils/project/path.go
@@ -77,7 +77,7 @@ func PackageForPath(directory string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.Trim(absPath[len(srcPath(goPath)):], "/"), nil
+	return filepath.ToSlash(strings.Trim(absPath[len(srcPath(goPath)):], string(os.PathSeparator))), nil
 }
 
 // Subdirectories walkthroughs all subdirectories. The results contains itself.

--- a/utils/project/path_test.go
+++ b/utils/project/path_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2018 Caicloud Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package project
+
+import (
+	"testing"
+)
+
+func TestPackageForPath(t *testing.T) {
+	directory := "./test1"
+	dest := "github.com/caicloud/nirvana/utils/project/test1"
+	packagePath, err := PackageForPath(directory)
+	if err != nil {
+		t.Error(err)
+	}
+	if packagePath != dest {
+		t.Error(packagePath)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:
nirvana init cmd report an error on windows as follow:  
> FATAL 0312-11:49:06.321+08 init.go:49 \| can't format go source file pkg/apis/v1/ descriptors/descriptors.go: 6:4: unknown escape sequence (and 2 more errors)  

this PR fixed it.


**Special notes for your reviewer**:
@kdada 

```release-note
fix: init cmd path error on windows.
```