### PR TITLE
fix(#278): prevent WriteHeader from automatically calling when hijack used

### DIFF
--- a/service/context.go
+++ b/service/context.go
@@ -212,6 +212,8 @@ func (c *response) CloseNotify() <-chan bool {
 // Hijack is a disguise of http.response.Hijack().
 func (c *response) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if h, ok := c.writer.(http.Hijacker); ok {
+		// Prevent WriteHeader from automatically calling.
+		c.statusCode = 200
 		return h.Hijack()
 	}
 	return nil, nil, noConnectionHijacker.Error()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

It will not be calling `WriteHeader` when upgrade http to websocket. 

Nirvana always check `HeaderWritable` and call `WriteHeader` , this will cause the `net/http` output warning log.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #278 

**Special notes for your reviewer**:

/cc @kdada 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
