### PR TITLE
fix(operator): panic when call Operate with nil data

### DIFF
--- a/definition/helper.go
+++ b/definition/helper.go
@@ -226,7 +226,14 @@ func (o *operatorRef) Out() reflect.Type {
 
 // Operate operates an object and return one.
 func (o *operatorRef) Operate(ctx context.Context, field string, object interface{}) (interface{}, error) {
-	results := o.value.Call([]reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(field), reflect.ValueOf(object)})
+	var objectValue reflect.Value
+	if object == nil {
+		objectValue = reflect.Zero(o.in)
+	} else {
+		objectValue = reflect.ValueOf(object)
+	}
+
+	results := o.value.Call([]reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(field), objectValue})
 	v := results[1]
 	if v.IsNil() {
 		return results[0].Interface(), nil

--- a/definition/helper_test.go
+++ b/definition/helper_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 Caicloud Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	"context"
+	"testing"
+)
+
+func TestOperatorRefOperate(t *testing.T) {
+	f := func(ctx context.Context, key string, value error) (error, error) {
+		return value, nil
+	}
+	op := OperatorFunc("OperatorRefOperate", f)
+	v, err := op.Operate(context.TODO(), "", nil)
+	if err != nil {
+		t.Fatalf("Operate Result[1] not be nil")
+	}
+	if v != nil {
+		t.Fatalf("Operate Result[0] not be nil")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

fix panic when use operator in DestinationHandler. example:

```
var getMessage = def.Definition{
	Method:      def.Get,
	Summary:     "Get Message",
	Description: "Get a message by id",
	Function:    message.GetMessage,
	Parameters: []def.Parameter{
		def.PathParameterFor("message", "Message id"),
	},
	Results: []def.Result{
		{
			Destination: def.Data,
			Description: "",
		},
		{
			Destination: def.Error,
			Operators: []def.Operator{
				def.OperatorFunc("Error", func(context.Context, string, error) (error, error) {
					return nil, nil
				}),
			},
		},
	},
}

// GetMessage return a message by id.
func GetMessage(ctx context.Context, id int) (*Message, error) {
	return &Message{
		ID:      id,
		Title:   "This is an example",
		Content: "Example content",
	}, nil
}
```

when access the url, the panic happend:

```
2019/07/01 21:18:04 http: panic serving [::1]:57322: reflect: Call using zero Value argument
goroutine 19 [running]:
net/http.(*conn).serve.func1(0xc0001b6000)
        /usr/local/Cellar/go/1.12.4/libexec/src/net/http/server.go:1769 +0x139
panic(0x1551520, 0xc0000a79a0)
        /usr/local/Cellar/go/1.12.4/libexec/src/runtime/panic.go:522 +0x1b5
reflect.Value.call(0x1582920, 0x163eb38, 0x13, 0x161880d, 0x4, 0xc0000dd5b0, 0x3, 0x3, 0x1551320, 0xc000145201, ...)
        /usr/local/Cellar/go/1.12.4/libexec/src/reflect/value.go:372 +0x14ff
reflect.Value.Call(0x1582920, 0x163eb38, 0x13, 0xc0000dd5b0, 0x3, 0x3, 0x158d900, 0x14fb32b, 0x14fb328)
        /usr/local/Cellar/go/1.12.4/libexec/src/reflect/value.go:308 +0xa4
github.com/caicloud/nirvana/definition.(*operatorRef).Operate(0xc0000ae000, 0x16ec7c0, 0xc000161030, 0x1618d0e, 0x5, 0x0, 0x0, 0x2, 0x2, 0x7, ...)
        /Users/caicloud/workspace/golang/src/github.com/caicloud/nirvana/definition/helper.go:229 +0x294
github.com/caicloud/nirvana/service.(*executor).Execute(0xc00014e180, 0x16ec7c0, 0xc000161030, 0x5d1a080c, 0xd72a080)
        /Users/caicloud/workspace/golang/src/github.com/caicloud/nirvana/service/executor.go:468 +0x638
github.com/caicloud/nirvana/service/router.(*middlewareExecutor).Continue(0xc000145140, 0x16ec7c0, 0xc000161030, 0x0, 0x1)
        /Users/caicloud/workspace/golang/src/github.com/caicloud/nirvana/service/router/executor.go:49 +0x61
github.com/caicloud/nirvana/plugins/metrics.newMetricsMiddleware.func1(0x16ec7c0, 0xc000161030, 0x1cc41d8, 0xc000145140, 0xc000145140, 0xc0000a8418)
        /Users/caicloud/workspace/golang/src/github.com/caicloud/nirvana/plugins/metrics/metrics.go:81 +0xaf
github.com/caicloud/nirvana/service.(*builder).Build.func1(0x16ec7c0, 0xc000161030, 0x16df620, 0xc000145140, 0x15d6640, 0xc000161030)
        /Users/caicloud/workspace/golang/src/github.com/caicloud/nirvana/service/builder.go:261 +0x7f
github.com/caicloud/nirvana/service/router.(*middlewareExecutor).Continue(0xc000145140, 0x16ec7c0, 0xc000161030, 0xc000161030, 0x1affa78)
        /Users/caicloud/workspace/golang/src/github.com/caicloud/nirvana/service/router/executor.go:55 +0xc7
github.com/caicloud/nirvana/plugins/reqlog.(*reqlogInstaller).Install.func1.1(0x16ec7c0, 0xc000161030, 0x1cc41d8, 0xc000145140, 0xc000145140, 0xa0)
        /Users/caicloud/workspace/golang/src/github.com/caicloud/nirvana/plugins/reqlog/reqlog.go:65 +0xe8
github.com/caicloud/nirvana/service.(*builder).Build.func1(0x16ec7c0, 0xc000161030, 0x16df620, 0xc000145140, 0xc00014e180, 0xc000059c18)
        /Users/caicloud/workspace/golang/src/github.com/caicloud/nirvana/service/builder.go:261 +0x7f
github.com/caicloud/nirvana/service/router.(*middlewareExecutor).Continue(0xc000145140, 0x16ec7c0, 0xc000161030, 0x0, 0x0)
        /Users/caicloud/workspace/golang/src/github.com/caicloud/nirvana/service/router/executor.go:55 +0xc7
github.com/caicloud/nirvana/service/router.(*middlewareExecutor).Execute(0xc000145140, 0x16ec7c0, 0xc000161030, 0x0, 0x0)
        /Users/caicloud/workspace/golang/src/github.com/caicloud/nirvana/service/router/executor.go:42 +0x79
github.com/caicloud/nirvana/service.(*service).ServeHTTP(0xc000159360, 0x16ead40, 0xc0001c6000, 0xc000130300)
        /Users/caicloud/workspace/golang/src/github.com/caicloud/nirvana/service/builder.go:322 +0x344
net/http.serverHandler.ServeHTTP(0xc000097860, 0x16ead40, 0xc0001c6000, 0xc000130300)
        /usr/local/Cellar/go/1.12.4/libexec/src/net/http/server.go:2774 +0xa8
net/http.(*conn).serve(0xc0001b6000, 0x16ec480, 0xc0000c8cc0)
        /usr/local/Cellar/go/1.12.4/libexec/src/net/http/server.go:1878 +0x851
created by net/http.(*Server).Serve
        /usr/local/Cellar/go/1.12.4/libexec/src/net/http/server.go:2884 +0x2f4
```

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭，caicloud/quality 请用这个。-->

**Special notes for your reviewer**:

/cc @your-reviewer

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
