### PR TITLE
feat(config): compatible with go flag package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"flag"
 	"os"
 	"reflect"
 	"sort"
@@ -273,6 +274,12 @@ func (s *command) Execute(descriptors ...definition.Descriptor) error {
 
 // ExecuteWithConfig runs nirvana server from a custom config.
 func (s *command) ExecuteWithConfig(cfg *nirvana.Config) error {
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	// https://github.com/kubernetes/kubernetes/issues/17162#issuecomment-225596212
+	if err := flag.CommandLine.Parse([]string{}); err != nil {
+		panic(err)
+	}
+
 	return s.Command(cfg).Execute()
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

In some cases, nirvana server uses some components that use glog/klog, and now those components have no way to output(or control) the log.

After manually add the given `flag.FlagSet` to the `pflag.FlagSet`:

```console
$ ./addon -h
ConfigKey-ENV-Flag Mapping Table

   Config Key   ENV          Flag    Current Value
1  server.cert  SERVER_CERT  --cert
2  server.ip    SERVER_IP    --ip
3  server.key   SERVER_KEY   --key
4  server.port  SERVER_PORT  --port  2233

Usage:
  server [flags]

Flags:
      --alsologtostderr                  log to standard error as well as files
      --cert string                      TLS certificate (PEM format) for HTTPS
  -h, --help                             help for server
      --ip string                        Nirvana server listening IP
      --key string                       TLS private key (PEM format) for HTTPS
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files
      --port uint16                      Nirvana server listening Port (default 2233)
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          log level for V logs
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

$ ./addon
INFO  0813-14:43:37.543+08 config.go:315 | Listening on :2233
INFO  0813-14:43:37.543+08 builder.go:231 | Definitions: 1 Middlewares: 0 Path: /apis/v1alpha1/checkparameters
INFO  0813-14:43:37.544+08 builder.go:246 |   Method: Update Consumes: [*/*] Produces: [application/json]
INFO  0813-14:44:19.740+08 handler.go:26 | CheckStorageParameters[type=glusterfs] start
INFO  0813-14:44:20.062+08 handler.go:43 | CheckStorageParameters[type=glusterfs] done

$ ./addon --logtostderr
INFO  0813-14:44:27.589+08 config.go:315 | Listening on :2233
INFO  0813-14:44:27.589+08 builder.go:231 | Definitions: 1 Middlewares: 0 Path: /apis/v1alpha1/checkparameters
INFO  0813-14:44:27.590+08 builder.go:246 |   Method: Update Consumes: [*/*] Produces: [application/json]
I0813 14:44:31.069129    2859 handler.go:23] hello from glog
INFO  0813-14:44:31.069+08 handler.go:26 | CheckStorageParameters[type=glusterfs] start
INFO  0813-14:44:31.589+08 handler.go:43 | CheckStorageParameters[type=glusterfs] done
```

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭，caicloud/quality 请用这个。-->

**Special notes for your reviewer**:

/cc @kdada 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips from Kubernetes community:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
