### PR TITLE
feat(plugin): add a type parameter for the health check plugin

### DIFF
--- a/examples/getting-started/healthcheck/echo.go
+++ b/examples/getting-started/healthcheck/echo.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 
+	"github.com/caicloud/nirvana"
 	"github.com/caicloud/nirvana/config"
 	"github.com/caicloud/nirvana/definition"
 	"github.com/caicloud/nirvana/errors"
@@ -63,35 +64,26 @@ func Echo(ctx context.Context, msg string) (string, error) {
 
 func main() {
 	cmd := config.NewDefaultNirvanaCommand()
-	checkFunc := func(ctx context.Context, checkType string) error {
-		switch checkType {
-		case healthcheck.LivenessCheck:
-			// do something
-			return nil
-		case healthcheck.ReadinessCheck:
-			// do something
-			return nil
-		default:
-			return errors.BadRequest.Build("error", "unknown type ${type}").Error(checkType)
-		}
-	}
-
-	// cfg := nirvana.NewDefaultConfig()
-	// cfg.Configure(
-	// 	nirvana.Descriptor(echo),
-	// 	healthcheck.CheckerWithType(checkFunc),
-	// 	// healthcheck.Checker(func(ctx context.Context) error {
-	// 	// 	return nil
-	// 	// }),
-	// )
-	// if err := cmd.ExecuteWithConfig(cfg); err != nil {
-	// 	log.Fatal(err)
-	// }
-
-	cmd.EnablePlugin(
-		healthcheck.NewCheckerWithType("", checkFunc),
+	cfg := nirvana.NewDefaultConfig()
+	cfg.Configure(
+		nirvana.Descriptor(echo),
+		healthcheck.CheckerWithType(func(ctx context.Context, checkType string) error {
+			switch checkType {
+			case healthcheck.LivenessCheck:
+				// do something
+				return nil
+			case healthcheck.ReadinessCheck:
+				// do something
+				return nil
+			default:
+				return errors.BadRequest.Build("error", "unknown type ${type}").Error(checkType)
+			}
+		}),
+		// healthcheck.Checker(func(ctx context.Context) error {
+		// 	return nil
+		// }),
 	)
-	if err := cmd.Execute(echo); err != nil {
+	if err := cmd.ExecuteWithConfig(cfg); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/getting-started/healthcheck/echo.go
+++ b/examples/getting-started/healthcheck/echo.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Caicloud Authors
+Copyright 2019 Caicloud Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -63,19 +63,33 @@ func Echo(ctx context.Context, msg string) (string, error) {
 
 func main() {
 	cmd := config.NewDefaultNirvanaCommand()
+	checkFunc := func(ctx context.Context, checkType string) error {
+		switch checkType {
+		case healthcheck.LivenessCheck:
+			// do something
+			return nil
+		case healthcheck.ReadinessCheck:
+			// do something
+			return nil
+		default:
+			return errors.BadRequest.Build("error", "unknown type ${type}").Error(checkType)
+		}
+	}
+
+	// cfg := nirvana.NewDefaultConfig()
+	// cfg.Configure(
+	// 	nirvana.Descriptor(echo),
+	// 	healthcheck.CheckerWithType(checkFunc),
+	// 	// healthcheck.Checker(func(ctx context.Context) error {
+	// 	// 	return nil
+	// 	// }),
+	// )
+	// if err := cmd.ExecuteWithConfig(cfg); err != nil {
+	// 	log.Fatal(err)
+	// }
+
 	cmd.EnablePlugin(
-		healthcheck.NewOption(func(ctx context.Context, checkType string) error {
-			switch checkType {
-			case "liveness":
-				// do something
-				return nil
-			case "readiness":
-				// do something
-				return nil
-			default:
-				return errors.BadRequest.Build("error", "unknown type ${type}").Error(checkType)
-			}
-		}),
+		healthcheck.NewCheckerWithType("", checkFunc),
 	)
 	if err := cmd.Execute(echo); err != nil {
 		log.Fatal(err)

--- a/examples/getting-started/healthcheck/echo.go
+++ b/examples/getting-started/healthcheck/echo.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2018 Caicloud Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+
+	"github.com/caicloud/nirvana/config"
+	"github.com/caicloud/nirvana/definition"
+	"github.com/caicloud/nirvana/errors"
+	"github.com/caicloud/nirvana/log"
+	"github.com/caicloud/nirvana/plugins/healthcheck"
+)
+
+var echo = definition.Descriptor{
+	Path:        "/echo",
+	Description: "Echo API",
+	Definitions: []definition.Definition{
+		{
+			Method:   definition.Get,
+			Function: Echo,
+			Consumes: []string{definition.MIMEAll},
+			Produces: []string{definition.MIMEJSON},
+			Parameters: []definition.Parameter{
+				{
+					Source:      definition.Query,
+					Name:        "msg",
+					Description: "Corresponding to the second parameter",
+				},
+			},
+			Results: []definition.Result{
+				{
+					Destination: definition.Data,
+					Description: "Corresponding to the first result",
+				},
+				{
+					Destination: definition.Error,
+					Description: "Corresponding to the second result",
+				},
+			},
+		},
+	},
+}
+
+// API function.
+func Echo(ctx context.Context, msg string) (string, error) {
+	return msg, nil
+}
+
+func main() {
+	cmd := config.NewDefaultNirvanaCommand()
+	cmd.EnablePlugin(
+		healthcheck.NewOption(func(ctx context.Context, checkType string) error {
+			switch checkType {
+			case "liveness":
+				// do something
+				return nil
+			case "readiness":
+				// do something
+				return nil
+			default:
+				return errors.BadRequest.Build("error", "unknown type ${type}").Error(checkType)
+			}
+		}),
+	)
+	if err := cmd.Execute(echo); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/getting-started/healthcheck/echo.go
+++ b/examples/getting-started/healthcheck/echo.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Caicloud Authors
+Copyright 2018 Caicloud Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/plugins/healthcheck/healthz.go
+++ b/plugins/healthcheck/healthz.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/caicloud/nirvana"
-	nirvanaconfig "github.com/caicloud/nirvana/config"
 	"github.com/caicloud/nirvana/definition"
 	"github.com/caicloud/nirvana/service"
 )
@@ -188,33 +187,6 @@ func (p *Option) Configure(cfg *nirvana.Config) error {
 	cfg.Configure(
 		Path(p.Path),
 		Checker(p.checker),
-	)
-	return nil
-}
-
-type checkerWithType struct {
-	path    string
-	checker HealthCheckerWithType
-}
-
-// NewCheckerWithType returns a health check plugin with a type parameter.
-func NewCheckerWithType(path string, checker HealthCheckerWithType) nirvanaconfig.Plugin {
-	return &checkerWithType{
-		path:    path,
-		checker: checker,
-	}
-}
-
-// Name returns plugin name.
-func (p *checkerWithType) Name() string {
-	return ExternalConfigName
-}
-
-// Configure configures nirvana config via current options.
-func (p *checkerWithType) Configure(cfg *nirvana.Config) error {
-	cfg.Configure(
-		Path(p.path),
-		CheckerWithType(p.checker),
 	)
 	return nil
 }

--- a/plugins/healthcheck/healthz.go
+++ b/plugins/healthcheck/healthz.go
@@ -29,9 +29,10 @@ func init() {
 }
 
 // HealthChecker checks if current server is healthy.
-type HealthChecker func(ctx context.Context) error
+// The `checkType` parameter indicates the type of health check, such as liveness or readiness.
+type HealthChecker func(ctx context.Context, checkType string) error
 
-func defaultHealthChecker(ctx context.Context) error {
+func defaultHealthChecker(ctx context.Context, checkType string) error {
 	return nil
 }
 
@@ -60,8 +61,11 @@ func (i *healthcheckInstaller) Install(builder service.Builder, cfg *nirvana.Con
 			Consumes: []string{definition.MIMEAll},
 			Produces: []string{definition.MIMEAll},
 			Definitions: []definition.Definition{{
-				Method:   definition.Get,
-				Results:  []definition.Result{definition.ErrorResult()},
+				Method:  definition.Get,
+				Results: []definition.Result{definition.ErrorResult()},
+				Parameters: []definition.Parameter{
+					definition.QueryParameterFor("type", "the type of health check"),
+				},
 				Function: c.checker,
 			}},
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add a type parameter for the health check plugin to support different check types, such as readiness requires more check steps than liveness.

If this change makes sense, I'll update the document soon

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @kdada 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
