### PR TITLE
fix(service): fix a problem in the file parameter generator

### DIFF
--- a/service/source.go
+++ b/service/source.go
@@ -257,7 +257,7 @@ func (g *FileParameterGenerator) Generate(ctx context.Context, vc ValueContainer
 	if !ok {
 		return nil, nil
 	}
-	return repeatableCloserForFile{file, false}, nil
+	return &repeatableCloserForFile{file, false}, nil
 }
 
 // BodyParameterGenerator is used to generate object or body reader by value from request body.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

return the struct instance instead of the pointer of it will cause panic:

```
reflect: Call using service.repeatableCloserForFile as type multipart.File
```

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @kdada @hezhizhen 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
