### PR TITLE
feat(*): support serving the API documentation page when the server starts

### DIFF
--- a/definition/helper.go
+++ b/definition/helper.go
@@ -33,6 +33,7 @@ const (
 	MIMEAll         = "*/*"
 	MIMENone        = ""
 	MIMEText        = "text/plain"
+	MIMEHTML        = "text/html"
 	MIMEJSON        = "application/json"
 	MIMEXML         = "application/xml"
 	MIMEOctetStream = "application/octet-stream"

--- a/examples/api-basic/main.go
+++ b/examples/api-basic/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"github.com/caicloud/nirvana"
 	"github.com/caicloud/nirvana/config"
 	"github.com/caicloud/nirvana/examples/api-basic/api/v1"
 	"github.com/caicloud/nirvana/examples/api-basic/api/v2"
@@ -25,7 +26,12 @@ import (
 
 func main() {
 	cmd := config.NewDefaultNirvanaCommand()
-	if err := cmd.Execute(v1.Descriptor(), v2.Descriptor()); err != nil {
+	cfg := nirvana.NewDefaultConfig()
+	cfg.Configure(
+		nirvana.Descriptor(v1.Descriptor(), v2.Descriptor()),
+		nirvana.APIDocs("github.com/caicloud/nirvana/examples/api-basic", "/docs"),
+	)
+	if err := cmd.ExecuteWithConfig(cfg); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/api-basic/nirvana.yaml
+++ b/examples/api-basic/nirvana.yaml
@@ -1,0 +1,23 @@
+project: myproject
+description: This project uses nirvana as API framework
+schemes:
+- http
+hosts:
+- localhost:8080
+contacts:
+- name: nobody
+  email: nobody@nobody.io
+  description: Maintain this project
+versions:
+- name: v1
+  description: The v1 version is the first version of this project
+  rules:
+  - prefix: /api/v1
+    regexp: ""
+    replacement: ""
+- name: v2
+  description: The v2 version is the first version of this project
+  rules:
+  - prefix: /api/v2
+    regexp: ""
+    replacement: ""

--- a/nirvana.go
+++ b/nirvana.go
@@ -18,8 +18,11 @@ package nirvana
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"path"
 	"sync"
 	"sync/atomic"
 
@@ -27,6 +30,9 @@ import (
 	"github.com/caicloud/nirvana/errors"
 	"github.com/caicloud/nirvana/log"
 	"github.com/caicloud/nirvana/service"
+	"github.com/caicloud/nirvana/utils/api"
+	"github.com/caicloud/nirvana/utils/generators/swagger"
+	"github.com/caicloud/nirvana/utils/project"
 )
 
 // Server is a complete API server.
@@ -69,6 +75,13 @@ type Config struct {
 	// locked is for locking current config. If the field
 	// is not 0, any modification causes panic.
 	locked int32
+
+	// options for generating API docs
+
+	// root is the absolute path of the current project.
+	root string
+	// apiDocsPath is the path to the API documentation page, empty means do not serve the documentation page.
+	apiDocsPath string
 }
 
 // lock locks config. If succeed, it will return ture.
@@ -197,6 +210,51 @@ func NewServer(c *Config) Server {
 
 var noConfigInstaller = errors.InternalServerError.Build("Nirvana:NoConfigInstaller", "no config installer for external config name ${name}")
 
+func (s *server) buildAPIDocs(definitions *api.Definitions) (map[string][]byte, error) {
+	var (
+		config *project.Config
+		err    error
+	)
+	config, _ = project.LoadDefaultProjectFile(s.config.root)
+	if config == nil {
+		config = &project.Config{
+			Root:        s.config.root,
+			Project:     "Unknown Project",
+			Description: "This project does not have a project config.",
+			Schemes:     []string{"http"},
+			Hosts:       []string{"localhost"},
+			Versions: []project.Version{
+				{
+					Name: "unversioned",
+					PathRules: []project.PathRule{
+						{
+							Prefix: "/",
+						},
+					},
+				},
+			},
+		}
+		log.Warning("can't find project file, instead by default config")
+	}
+
+	generator := swagger.NewDefaultGenerator(config, definitions)
+	swaggers, err := generator.Generate()
+	if err != nil {
+		return nil, err
+	}
+
+	files := make(map[string][]byte, len(swaggers))
+	for _, sw := range swaggers {
+		data, err := json.MarshalIndent(sw, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+
+		files[sw.Info.Version] = data
+	}
+	return files, nil
+}
+
 // Builder create a service builder for current server. Don't use this method directly except
 // there is a special server to hold http services. After server shutdown, clean resources via
 // returned cleaner.
@@ -215,6 +273,53 @@ func (s *server) Builder() (builder service.Builder, cleaner func() error, err e
 	if err := builder.AddDescriptor(s.config.descriptors...); err != nil {
 		return nil, nil, err
 	}
+
+	if s.config.root != "" {
+		typeContainer := api.NewTypeContainer()
+		analyzer := api.NewAnalyzer(s.config.root)
+		result, err := api.NewPathDefinitions(typeContainer, builder.Definitions())
+		if err != nil {
+			return nil, nil, err
+		}
+		if err = typeContainer.Complete(analyzer); err != nil && err.Error() != "[]" {
+			return nil, nil, err
+		}
+		definitions := &api.Definitions{
+			Definitions: result,
+			Types:       typeContainer.Types(),
+		}
+		files, err := s.buildAPIDocs(definitions)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// write API json files
+		if err = api.WriteFiles(s.config.root, files); err != nil {
+			return nil, nil, err
+		}
+
+		// serve the API docs page
+		if s.config.apiDocsPath != "" {
+			apiDescriptor := make([]definition.Descriptor, 0, len(files)+1)
+			versions := make([]string, 0, len(files))
+			for v, data := range files {
+				versions = append(versions, v)
+				apiDescriptor = append(apiDescriptor, api.DescriptorForData(api.PathForVersion(s.config.apiDocsPath, v), data, definition.MIMEJSON))
+			}
+			data, err := api.GenSwaggerPageData(s.config.apiDocsPath, versions)
+			if err != nil {
+				return nil, nil, err
+			}
+			apiDescriptor = append(
+				apiDescriptor,
+				api.DescriptorForData(s.config.apiDocsPath, data, definition.MIMEHTML),
+			)
+			if err = builder.AddDescriptor(apiDescriptor...); err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
 	if err := s.config.forEach(func(name string, config interface{}) error {
 		installer := ConfigInstallerFor(name)
 		if installer == nil {
@@ -379,6 +484,27 @@ func Filter(filters ...service.Filter) Configurer {
 func Modifier(modifiers ...service.DefinitionModifier) Configurer {
 	return func(c *Config) error {
 		c.modifiers = append(c.modifiers, modifiers...)
+		return nil
+	}
+}
+
+// APIDocs returns a configurer to set API docs generation related options.
+func APIDocs(modulePath, apiDocsPath string) Configurer {
+	return func(c *Config) error {
+		if modulePath == "" {
+			return fmt.Errorf("the module path can't be empty")
+		}
+		var err error
+		root := path.Join(os.Getenv("GOPATH"), "src", modulePath)
+		s, _ := os.Stat(root)
+		if s == nil || !s.IsDir() {
+			root, err = os.Getwd()
+			if err != nil {
+				return err
+			}
+		}
+		c.root = root
+		c.apiDocsPath = apiDocsPath
 		return nil
 	}
 }

--- a/service/builder.go
+++ b/service/builder.go
@@ -77,7 +77,7 @@ func (b *builder) Filters() []Filter {
 	return result
 }
 
-// AddFilters add filters to filter requests.
+// AddFilter add filters to filter requests.
 func (b *builder) AddFilter(filters ...Filter) {
 	b.filters = append(b.filters, filters...)
 }

--- a/service/content.go
+++ b/service/content.go
@@ -61,6 +61,7 @@ var producers = map[string]Producer{
 	definition.MIMEJSON:        &JSONSerializer{},
 	definition.MIMEXML:         &XMLSerializer{},
 	definition.MIMEOctetStream: NewSimpleSerializer(definition.MIMEOctetStream),
+	definition.MIMEHTML:        NewSimpleSerializer(definition.MIMEHTML),
 }
 
 // AllConsumers returns all consumers.

--- a/utils/api/utils.go
+++ b/utils/api/utils.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 Caicloud Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package api
 
 import (

--- a/utils/api/utils.go
+++ b/utils/api/utils.go
@@ -1,0 +1,145 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/caicloud/nirvana/definition"
+)
+
+// PathForVersion returns the path of API file.
+func PathForVersion(root, version string) string {
+	return path.Join(root, fmt.Sprintf("/api.%s.json", version))
+}
+
+// WriteFiles writes the API data into files.
+func WriteFiles(output string, apis map[string][]byte) error {
+	dir, err := filepath.Abs(output)
+	if err != nil {
+		return err
+	}
+	if err = os.MkdirAll(dir, 0775); err != nil {
+		return err
+	}
+	for version, data := range apis {
+		file := filepath.Join(dir, fmt.Sprintf("api.%s.json", version))
+		if err = ioutil.WriteFile(file, data, 0664); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GenSwaggerPageData generates a Swagger UI page based on the given API files.
+func GenSwaggerPageData(root string, versions []string) ([]byte, error) {
+	index := `
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Swagger UI</title>
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3.25.0/swagger-ui.css" >
+    <link rel="icon" type="image/png" href="https://unpkg.com/swagger-ui-dist@3.25.0/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="https://unpkg.com/swagger-ui-dist@3.25.0/favicon-16x16.png" sizes="16x16" />
+    <style>
+      html
+      {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
+      *,
+      *:before,
+      *:after
+      {
+        box-sizing: inherit;
+      }
+      body
+      {
+        margin:0;
+        background: #fafafa;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@3.25.0/swagger-ui-bundle.js"> </script>
+    <script src="https://unpkg.com/swagger-ui-dist@3.25.0/swagger-ui-standalone-preset.js"> </script>
+    <script>
+	  // list of APIS
+      var apis = [
+        {{ range $i, $v := . }}
+        {
+            name: '{{ $v.Name }}',
+            url: '{{ $v.Path }}'
+        },
+		{{ end }}
+      ];
+    window.onload = function() {
+      // Begin Swagger UI call region
+      const ui = SwaggerUIBundle({
+        urls: apis,
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout"
+      })
+      // End Swagger UI call region
+      window.ui = ui
+    }
+  </script>
+  </body>
+</html>
+`
+	tmpl, err := template.New("index.html").Parse(index)
+	if err != nil {
+		return nil, err
+	}
+	data := make([]struct {
+		Name string
+		Path string
+	}, 0, len(versions))
+	for _, v := range versions {
+		data = append(data, struct {
+			Name string
+			Path string
+		}{v, PathForVersion(root, v)})
+	}
+	buf := bytes.NewBuffer(nil)
+	if err = tmpl.Execute(buf, data); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// DescriptorForData generates a Descriptor for API docs page.
+func DescriptorForData(path string, data []byte, contentType string) definition.Descriptor {
+	return definition.Descriptor{
+		Path: path,
+		Definitions: []definition.Definition{
+			{
+				Method:   definition.Get,
+				Consumes: []string{definition.MIMENone},
+				Produces: []string{contentType},
+				Function: func(context.Context) ([]byte, error) {
+					return data, nil
+				},
+				Parameters: []definition.Parameter{},
+				Results:    definition.DataErrorResults(""),
+			},
+		},
+	}
+}

--- a/utils/generators/swagger/generator.go
+++ b/utils/generators/swagger/generator.go
@@ -454,6 +454,10 @@ func (g *Generator) generateParameter(param *api.Parameter) []spec.Parameter {
 			parameter.Items.Format = schema.Items.Schema.Format
 		}
 		parameter.Schema = nil
+	} else {
+		// add parameter name for body, it required by swagger ui,
+		// cause api.Parameter.Name is always nil when In is body
+		parameter.Name = "body"
 	}
 
 	if len(param.Default) > 0 {

--- a/utils/generators/swagger/generator.go
+++ b/utils/generators/swagger/generator.go
@@ -439,7 +439,8 @@ func (g *Generator) generateParameter(param *api.Parameter) []spec.Parameter {
 	if len(param.Default) <= 0 {
 		parameter.Required = true
 	}
-	if parameter.In != "body" {
+	body := "body"
+	if parameter.In != body {
 		// Only body parameter can hold a schema. Other parameters uses type
 		// and format.
 		parameter.Type = schema.Type[0]
@@ -457,7 +458,7 @@ func (g *Generator) generateParameter(param *api.Parameter) []spec.Parameter {
 	} else {
 		// add parameter name for body, it required by swagger ui,
 		// cause api.Parameter.Name is always nil when In is body
-		parameter.Name = "body"
+		parameter.Name = body
 	}
 
 	if len(param.Default) > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

We can now choose to serve the API docs page with the API server itself, take api-basic example project as an example, with this simple config we can let nirvana generates the API docs file and serves the API docs page when the server starts:

```go
cfg.Configure(
	nirvana.Descriptor(v1.Descriptor(), v2.Descriptor()),
	nirvana.APIDocs("github.com/caicloud/nirvana/examples/api-basic", "/docs"),
)
```

Start the server, API docs related pages will serve under `/docs` path:

```
INFO  0408-16:45:44.066+08 config.go:309 | Listening on :8080
INFO  0408-16:45:44.608+08 builder.go:231 | Definitions: 1 Middlewares: 0 Path: /api/v1/applications
INFO  0408-16:45:44.608+08 builder.go:246 |   Method: Create Consumes: [application/json] Produces: [application/json]
INFO  0408-16:45:44.608+08 builder.go:231 | Definitions: 1 Middlewares: 0 Path: /api/v2/applications
INFO  0408-16:45:44.608+08 builder.go:246 |   Method: Create Consumes: [application/json] Produces: [application/json]
INFO  0408-16:45:44.608+08 builder.go:231 | Definitions: 1 Middlewares: 0 Path: /docs/api.v1.json
INFO  0408-16:45:44.608+08 builder.go:246 |   Method: Get Consumes: [] Produces: [application/json]
INFO  0408-16:45:44.608+08 builder.go:231 | Definitions: 1 Middlewares: 0 Path: /docs/api.v2.json
INFO  0408-16:45:44.608+08 builder.go:246 |   Method: Get Consumes: [] Produces: [application/json]
INFO  0408-16:45:44.608+08 builder.go:231 | Definitions: 1 Middlewares: 0 Path: /docs
INFO  0408-16:45:44.608+08 builder.go:246 |   Method: Get Consumes: [] Produces: [text/html]
```

<img width="1245" alt="Screen Shot 2020-04-08 at 16 34 31" src="https://user-images.githubusercontent.com/9134003/78764679-7a8a0e00-79b9-11ea-87e5-56addf10c425.png">

And API docs files will be created in the `...examples/api-basic` directory.

BTW, ReDoc has been replaced with the Swagger UI.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

close #290 

<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @supereagle @kdada 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
support serving the API documentation page when the server starts
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
