### PR TITLE
refactor(metrics): standardize Prometheus metrics

### DIFF
--- a/plugins/metrics/metrics.go
+++ b/plugins/metrics/metrics.go
@@ -62,19 +62,9 @@ func newMetricsMiddleware(namespace string) definition.Middleware {
 		},
 		[]string{"method", "path"},
 	)
-	requestLatenciesSummary := prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Namespace: namespace,
-			Name:      "request_latencies_summary",
-			Help:      "Response latency summary in milliseconds for each verb and resource.",
-			MaxAge:    time.Hour,
-		},
-		[]string{"method", "path"},
-	)
 
 	prometheus.MustRegister(requestCounter)
 	prometheus.MustRegister(requestLatencies)
-	prometheus.MustRegister(requestLatenciesSummary)
 
 	return func(ctx context.Context, next definition.Chain) error {
 		startTime := time.Now()
@@ -88,7 +78,6 @@ func newMetricsMiddleware(namespace string) definition.Middleware {
 
 		requestCounter.WithLabelValues(req.Method, path, getHTTPClient(req), req.Header.Get("Content-Type"), strconv.Itoa(resp.StatusCode())).Inc()
 		requestLatencies.WithLabelValues(req.Method, path).Observe(elapsed)
-		requestLatenciesSummary.WithLabelValues(req.Method, path).Observe(elapsed)
 
 		return err
 	}

--- a/plugins/metrics/metrics.go
+++ b/plugins/metrics/metrics.go
@@ -44,20 +44,23 @@ type config struct {
 type metricsInstaller struct{}
 
 func newMetricsMiddleware(namespace string) definition.Middleware {
+	constLabel := prometheus.Labels{"component": namespace}
 	requestCounter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "request_total",
-			Help:      "Counter of server requests broken out for each verb, API resource, and HTTP response code.",
+			Namespace:   namespace,
+			Name:        "request_total",
+			Help:        "Counter of server requests broken out for each verb, API resource, and HTTP response code.",
+			ConstLabels: constLabel,
 		},
 		[]string{"method", "path", "code"},
 	)
 	requestLatencies := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: namespace,
-			Name:      "request_duration_seconds",
-			Help:      "Response latency distribution in seconds for each verb, resource and client.",
-			Buckets:   prometheus.DefBuckets,
+			Namespace:   namespace,
+			Name:        "request_duration_seconds",
+			Help:        "Response latency distribution in seconds for each verb, resource and client.",
+			ConstLabels: constLabel,
+			Buckets:     prometheus.DefBuckets,
 		},
 		[]string{"method", "path"},
 	)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

This PR should be considered as a __breaking change__.

Refactored the metrics so that they meet the [K8 Instrumentation Guideline](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/instrumentation.md), the changes include:

1. Removed redundant labels.
2. Added a `component` label to all metrics; it takes the value of metric namespace.
3. Renamed according to the naming convention.
4. The Histogram type request duration metric use standard bucket sizes (which produce much more data, which will put more pressure on Prometheus, but is also more precise).
5. Changed the unit of the request duration metric from milliseconds to seconds.

As a result, the metrics should now look a lot like the APIServer request metrics. 

Also, removed the `Summary` type request latency metric: `Histogram` metrics function similarly to `Summary` metrics and are generally considered as the superior option, since it supports all quantile values instead of just 0.5, 0.9, and 0.99. This should balance out the extra data volume added by the refactored Histogram metric.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @supereagle @ddysher @iawia002 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
