### PR TITLE
feat(*): support to add a http.Handler directly to the router

### DIFF
--- a/definition/definition.go
+++ b/definition/definition.go
@@ -18,6 +18,7 @@ package definition
 
 import (
 	"context"
+	"net/http"
 	"reflect"
 )
 
@@ -202,6 +203,11 @@ type Definition struct {
 	// In some cases, succeessful data and error data should be generated in
 	// different ways.
 	ErrorProduces []string
+	// Handler is a http.Handler implementation, nirvana supports to add a http.Handler (e.g. httputil.ReverseProxy)
+	// directly to the router.
+	// If this field is not nil, there is no need to set the Function, Parameters, and Results fields.
+	// See examples/getting-started/handler for a real example.
+	Handler http.Handler
 	// Function is a function handler. It must be func type.
 	Function interface{}
 	// Parameters describes function parameters.

--- a/examples/getting-started/handler/main.go
+++ b/examples/getting-started/handler/main.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2020 Caicloud Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/caicloud/nirvana/config"
+	"github.com/caicloud/nirvana/definition"
+	"github.com/caicloud/nirvana/log"
+	"github.com/caicloud/nirvana/middlewares/reqlog"
+)
+
+func main() {
+	backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "this call was relayed by the reverse proxy")
+	}))
+	defer backendServer.Close()
+
+	rpURL, err := url.Parse(backendServer.URL)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	descriptors := []definition.Descriptor{
+		{
+			Path:        "/",
+			Description: "hello API",
+			Definitions: []definition.Definition{
+				{
+					Method:   definition.Get,
+					Consumes: []string{definition.MIMEAll},
+					Produces: []string{definition.MIMEJSON},
+					Function: func(ctx context.Context) (string, error) {
+						return "hello", nil
+					},
+					Results: definition.DataErrorResults(""),
+				},
+			},
+		},
+		{
+			Path:        "/proxy",
+			Description: "proxy API",
+			Middlewares: []definition.Middleware{
+				reqlog.Default(),
+			},
+			Definitions: []definition.Definition{
+				{
+					Method:   definition.Get,
+					Consumes: []string{definition.MIMEAll},
+					Produces: []string{definition.MIMEAll},
+					Handler:  httputil.NewSingleHostReverseProxy(rpURL),
+				},
+			},
+		},
+	}
+
+	cmd := config.NewDefaultNirvanaCommand()
+	if err = cmd.Execute(descriptors...); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/hack/verify_boilerplate.py
+++ b/hack/verify_boilerplate.py
@@ -154,7 +154,7 @@ def get_regexs():
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile('YEAR')
     # dates can be 2017 or 2018, company holder names can be anything
-    regexs["date"] = re.compile('(2017|2018)')
+    regexs["date"] = re.compile('(2017|2018|2019|2020)')
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell/python scripts

--- a/service/builder.go
+++ b/service/builder.go
@@ -151,6 +151,7 @@ func (b *builder) copyDefinition(d *definition.Definition, consumes []string, pr
 		Method:      d.Method,
 		Summary:     d.Summary,
 		Function:    d.Function,
+		Handler:     d.Handler,
 		Description: d.Description,
 	}
 	if len(d.Consumes) > 0 {

--- a/service/executor.go
+++ b/service/executor.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"path"
 	"reflect"
 	"runtime"
@@ -58,19 +59,16 @@ func (i *inspector) addDefinition(d definition.Definition) error {
 	if len(d.ErrorProduces) <= 0 {
 		return definitionNoErrorProduces.Error(d.Method, i.path)
 	}
-	if d.Function == nil {
+	if d.Function == nil && d.Handler == nil {
 		return definitionNoFunction.Error(d.Method, i.path)
 	}
-	value := reflect.ValueOf(d.Function)
-	if value.Kind() != reflect.Func {
-		return definitionInvalidFunctionType.Error(value.Type(), d.Method, i.path)
-	}
+
 	c := &executor{
-		logger:   i.logger,
-		method:   method,
-		code:     HTTPCodeFor(d.Method),
-		function: value,
+		logger: i.logger,
+		method: method,
+		code:   HTTPCodeFor(d.Method),
 	}
+
 	consumeAll := false
 	consumes := map[string]bool{}
 	for _, ct := range d.Consumes {
@@ -115,6 +113,19 @@ func (i *inspector) addDefinition(d definition.Definition) error {
 			}
 		}
 	}
+
+	if d.Handler != nil {
+		c.handler = d.Handler
+		i.executors[method] = append(i.executors[method], c)
+		return nil
+	}
+
+	value := reflect.ValueOf(d.Function)
+	if value.Kind() != reflect.Func {
+		return definitionInvalidFunctionType.Error(value.Type(), d.Method, i.path)
+	}
+	c.function = value
+
 	errorProduceAll := false
 	errorProduces := map[string]bool{}
 	for _, ct := range d.ErrorProduces {
@@ -371,6 +382,7 @@ type executor struct {
 	parameters     []parameter
 	results        []result
 	function       reflect.Value
+	handler        http.Handler
 }
 
 type parameter struct {
@@ -428,6 +440,11 @@ func (e *executor) Execute(ctx context.Context) (err error) {
 	if c == nil {
 		return noContext.Error()
 	}
+	if e.handler != nil {
+		e.handler.ServeHTTP(c.ResponseWriter(), c.Request())
+		return nil
+	}
+
 	paramValues := make([]reflect.Value, 0, len(e.parameters))
 	for _, p := range e.parameters {
 		result, err := p.generator.Generate(ctx, c.ValueContainer(), e.consumers, p.name, p.targetType)

--- a/service/utils.go
+++ b/service/utils.go
@@ -112,7 +112,7 @@ var definitionNoConsumes = errors.InternalServerError.Build("Nirvana:Service:Def
 var definitionNoProduces = errors.InternalServerError.Build("Nirvana:Service:DefinitionNoProduces", "no content type to produce in [${method}]${path}")
 var definitionNoErrorProduces = errors.InternalServerError.Build("Nirvana:Service:DefinitionNoErrorProduces",
 	"no content type to produce error in [${method}]${path}")
-var definitionNoFunction = errors.InternalServerError.Build("Nirvana:Service:DefinitionNoFunction", "no function in [${method}]${path}")
+var definitionNoFunction = errors.InternalServerError.Build("Nirvana:Service:DefinitionNoFunction", "no function or handler in [${method}]${path}")
 var definitionInvalidFunctionType = errors.InternalServerError.Build("Nirvana:Service:DefinitionInvalidFunctionType",
 	"${type} is not function in [${method}]${path}")
 

--- a/utils/api/definitions.go
+++ b/utils/api/definitions.go
@@ -95,6 +95,10 @@ type Definition struct {
 
 // NewDefinition creates openapi.Definition from definition.Definition.
 func NewDefinition(tc *TypeContainer, d *definition.Definition) (*Definition, error) {
+	if d.Function == nil {
+		return nil, nil
+	}
+
 	cd := &Definition{
 		Method:        d.Method,
 		HTTPMethod:    service.HTTPMethodFor(d.Method),
@@ -162,6 +166,9 @@ func NewDefinitions(tc *TypeContainer, definitions []definition.Definition) ([]D
 		cd, err := NewDefinition(tc, &d)
 		if err != nil {
 			return nil, err
+		}
+		if cd == nil {
+			continue
 		}
 		result[i] = *cd
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

This PR makes nirvana supports to add a http.Handler (e.g. httputil.ReverseProxy) directly to the router.

See examples/getting-started/handler for a real example.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

close #339 

<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @gaocegege 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
