### PR TITLE
fix(rpc): disallow duplicated rpc path

### DIFF
--- a/service/rpc/builder.go
+++ b/service/rpc/builder.go
@@ -107,7 +107,11 @@ func (b *builder) AddDescriptor(descriptors ...interface{}) error {
 			path = "/"
 		}
 		for _, action := range descriptor.Actions {
-			b.bindings[genRPCPath(path, action.Version, action.Name)] = &binding{
+			rpcPath := genRPCPath(path, action.Version, action.Name)
+			if _, ok := b.bindings[rpcPath]; ok {
+				return fmt.Errorf("duplicated rpc path: %s", rpcPath)
+			}
+			b.bindings[rpcPath] = &binding{
 				middlewares: descriptor.Middlewares,
 				definition:  b.genDefinition(action, descriptor.Consumes, descriptor.Produces, descriptor.Tags),
 			}

--- a/service/rpc/builder_test.go
+++ b/service/rpc/builder_test.go
@@ -303,6 +303,33 @@ func TestDefinitions(t *testing.T) {
 	}
 }
 
+func TestDuplicatedRPCPath(t *testing.T) {
+	const version = "2020-10-10"
+	action := definition.RPCAction{
+		Name:    "GetFoo",
+		Version: version,
+		Function: func() (string, error) {
+			return "", nil
+		},
+		Results: definition.DataErrorResults(""),
+	}
+	desc := definition.RPCDescriptor{
+		Path:        "/",
+		Description: "Test",
+		Consumes:    []string{definition.MIMEAll},
+		Produces:    []string{definition.MIMEAll},
+		Actions:     []definition.RPCAction{action, action},
+	}
+	builder := NewBuilder()
+	err := builder.AddDescriptor(desc)
+	if err == nil {
+		t.Fatal("Unexpected success")
+	}
+	if !strings.Contains(err.Error(), "duplicated rpc path") {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
 func BenchmarkServer(b *testing.B) {
 	u, _ := url.Parse("/?Action=GetEcho&Version=2020-01-01&name=alice")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Prevent users from setting duplicated RRC path by mistake.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @iawia002 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
