### PR TITLE
fix(config): add lock in Set function to avoid concurrent map writes when we run several servers at once

### DIFF
--- a/config/center.go
+++ b/config/center.go
@@ -19,13 +19,17 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/spf13/cast"
 	"github.com/spf13/viper"
 )
 
-var v = viper.New()
+var (
+	v    = viper.New()
+	lock sync.RWMutex
+)
 
 func init() {
 	// Initialize config paths.
@@ -72,6 +76,8 @@ func IsSet(key string) bool {
 // Will be used instead of values obtained via
 // flags, config file, ENV, default, or key/value store.
 func Set(key string, value interface{}) {
+	lock.Lock()
+	defer lock.Unlock()
 	v.Set(key, value)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

In the current design, if we start more than one server at the same time, eg:

```
cmd := config.NewNamedNirvanaCommand("server1", &config.Option{Port: 7070})
cmd2 := config.NewNamedNirvanaCommand("server2", &config.Option{Port: 7071})

go cmd.Execute(echo)
go cmd2.Execute(echo)

<-stopCh
```

This has the probability of causing the `concurrent map writes` error in the `Set` method

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @xpofei 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
