### PR TITLE
fix(pkg): ignore the invoke when the struct container the field which has the same type with itself

### DIFF
--- a/utils/generators/golang/helper.go
+++ b/utils/generators/golang/helper.go
@@ -313,6 +313,7 @@ func (h *helper) pkgs(typ *api.Type, extended bool) []string {
 				// The name may be composed of pkgPath and name, when the strcut
 				// containes itself recursive, such as slice ptr map, the functions pkgs will be invoked infinitely,
 				// ignore it.
+				// TODO the format of the name is error, should correct it.
 				childType, ok := h.definitions.Types[field.Type]
 				if !ok {
 					continue

--- a/utils/generators/golang/helper.go
+++ b/utils/generators/golang/helper.go
@@ -311,7 +311,7 @@ func (h *helper) pkgs(typ *api.Type, extended bool) []string {
 			localType := fmt.Sprintf("%s.%s", typ.PkgPath, typ.Name)
 			for _, field := range typ.Fields {
 				// The name may be composed of pkgPath and name, when the strcut
-				// containes itself recursive, such as slice ptr map, the functions pkgs will be invoked infinitely,
+				// contains itself recursive, such as slice ptr map, the functions pkgs will be invoked infinitely,
 				// ignore it.
 				// TODO the format of the name is error, should correct it.
 				childType, ok := h.definitions.Types[field.Type]
@@ -321,7 +321,7 @@ func (h *helper) pkgs(typ *api.Type, extended bool) []string {
 				if strings.HasSuffix(childType.Name, localType) {
 					continue
 				}
-				pkgs = append(pkgs, h.pkgs(h.definitions.Types[field.Type], extended)...)
+				pkgs = append(pkgs, h.pkgs(childType, extended)...)
 			}
 			return pkgs
 		}

--- a/utils/generators/golang/helper.go
+++ b/utils/generators/golang/helper.go
@@ -308,7 +308,18 @@ func (h *helper) pkgs(typ *api.Type, extended bool) []string {
 
 		if extended && typ.Kind == reflect.Struct {
 			pkgs := make([]string, 0, len(typ.Fields))
+			localType := fmt.Sprintf("%s.%s", typ.PkgPath, typ.Name)
 			for _, field := range typ.Fields {
+				// The name may be composed of pkgPath and name, when the strcut
+				// containes itself recursive, such as slice ptr map, the functions pkgs will be invoked infinitely,
+				// ignore it.
+				childType, ok := h.definitions.Types[field.Type]
+				if !ok {
+					continue
+				}
+				if strings.HasSuffix(childType.Name, localType) {
+					continue
+				}
 				pkgs = append(pkgs, h.pkgs(h.definitions.Types[field.Type], extended)...)
 			}
 			return pkgs


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

修复在生成 API 或者 client 的时候如果某个结构体定义里包含自身字段会无限循环的 bug

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @your-reviewer

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->