### PR TITLE
fix(*): determine if a string is a built-in type

### DIFF
--- a/utils/generators/golang/helper.go
+++ b/utils/generators/golang/helper.go
@@ -490,6 +490,53 @@ type nameContainer struct {
 	namer *typeNamer
 }
 
+var builtInTypes = map[string]bool{
+	"bool":        true,
+	"true":        true,
+	"false":       true,
+	"uint8 ":      true,
+	"uint16 ":     true,
+	"uint32 ":     true,
+	"uint64":      true,
+	"int8":        true,
+	"int16":       true,
+	"int32":       true,
+	"int64":       true,
+	"float32":     true,
+	"float64":     true,
+	"complex64":   true,
+	"complex128":  true,
+	"string":      true,
+	"int":         true,
+	"uint":        true,
+	"uintptr":     true,
+	"byte":        true,
+	"rune":        true,
+	"iota":        true,
+	"nil":         true,
+	"Type":        true,
+	"Type1":       true,
+	"IntegerType": true,
+	"FloatType":   true,
+	"ComplexType": true,
+	"append":      true,
+	"copy":        true,
+	"delete":      true,
+	"len":         true,
+	"cap":         true,
+	"make":        true,
+	"new":         true,
+	"complex":     true,
+	"real":        true,
+	"imag":        true,
+	"close":       true,
+	"panic":       true,
+	"recover":     true,
+	"print":       true,
+	"println":     true,
+	"error":       true,
+}
+
 func (n *nameContainer) proposeName(name string, typ api.TypeName, targetTypes ...string) string {
 	if name == "" {
 		name = n.deconstruct(typ)
@@ -504,7 +551,7 @@ func (n *nameContainer) proposeName(name string, typ api.TypeName, targetTypes .
 		name = string(name[0]|0x20) + name[1:]
 	}
 	// name may be `type` `int` `string` etc.
-	if token.Lookup(name).IsKeyword() || token.Lookup(name).IsLiteral() {
+	if token.Lookup(name).IsKeyword() || builtInTypes[name] {
 		name += "_"
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

`token.Lookup(name).IsLiteral()` cannot be used to determine if a string is a built-in type.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #425 
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @xpofei @whalecold 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
