### PR TITLE
feat(cors): Add a plugin to handle to handle CORS related requests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -486,6 +486,10 @@ func (s *command) registerFields(fs *pflag.FlagSet) {
 			fs.DurationVarP(v, f.longFlag, f.shortFlag, *v, f.description)
 
 		default:
+			// cannot found the appropriate flag type for cors function()
+			if strings.Contains(cast.ToString(f.key), ".cors.") && strings.HasSuffix(cast.ToString(f.key), "Func") {
+				continue
+			}
 			panic(errors.InternalServerError.Error("unrecognized type ${type} for ${key}", reflect.TypeOf(f.pointer).String(), f.key))
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pelletier/go-toml v1.7.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.8.0
+	github.com/rs/cors v1.7.0
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -294,6 +294,8 @@ github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
+github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/plugins/cors/cors.go
+++ b/plugins/cors/cors.go
@@ -1,0 +1,332 @@
+/*
+Copyright 2021 Caicloud Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cors
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/rs/cors"
+
+	"github.com/caicloud/nirvana"
+	"github.com/caicloud/nirvana/definition"
+	"github.com/caicloud/nirvana/log"
+	"github.com/caicloud/nirvana/service"
+)
+
+func init() {
+	nirvana.RegisterConfigInstaller(&corsInstaller{})
+}
+
+// ExternalConfigName is the external config name of request logger.
+const ExternalConfigName = "cors"
+
+// config is cors config.
+type config struct {
+	cors.Options
+	logger log.Logger
+}
+
+type corsInstaller struct {
+	cors *cors.Cors
+}
+
+// Name is the external config name.
+func (i *corsInstaller) Name() string {
+	return ExternalConfigName
+}
+
+// Install installs stuffs before server starting.
+func (i *corsInstaller) Install(builder service.Builder, cfg *nirvana.Config) error {
+	var err error
+	wrapper(cfg, func(c *config) {
+		resp_begin := i.buildCORSPolicies(c)
+		err = builder.AddDescriptor(definition.Descriptor{
+			Path: "/",
+			Middlewares: []definition.Middleware{
+				func(ctx context.Context, next definition.Chain) error {
+					httpCtx := service.HTTPContextFrom(ctx)
+
+					resp_begin(httpCtx)
+					err := next.Continue(ctx)
+					return err
+				},
+			},
+		})
+	})
+	return err
+}
+
+type injector func(ctx service.HTTPContext)
+
+func (i *corsInstaller) buildCORSPolicies(c *config) (end_resp injector) {
+	logger := c.logger
+	printer := func(msg ...interface{}) {
+		if logger != nil {
+			logger.Infoln(msg...)
+		} else {
+			log.Infoln(msg...)
+		}
+	}
+	corsHeaderGenerator := func(ctx service.HTTPContext) {
+		printer("corsHeaderGenerator: start")
+		i.cors = cors.New(c.Options)
+		i.cors.HandlerFunc(ctx.ResponseWriter(), ctx.Request())
+		printer("corsHeaderGenerator: end")
+	}
+	return func(ctx service.HTTPContext) {
+		corsHeaderGenerator(ctx)
+	}
+}
+
+// Uninstall uninstalls stuffs after server terminating.
+func (i *corsInstaller) Uninstall(service.Builder, *nirvana.Config) error {
+	return nil
+}
+
+// Disable returns a configurer to disable cors.
+func Disable() nirvana.Configurer {
+	return func(c *nirvana.Config) error {
+		c.Set(ExternalConfigName, nil)
+		return nil
+	}
+}
+
+// Default Configurer does nothing but ensure default config was set.
+func Default() nirvana.Configurer {
+	return func(c *nirvana.Config) error {
+		wrapper(c, func(c *config) {
+			c.logger = nil
+		})
+		return nil
+	}
+}
+
+// Logger Configurer sets logger.
+func Logger(l log.Logger) nirvana.Configurer {
+	return func(c *nirvana.Config) error {
+		wrapper(c, func(c *config) {
+			c.logger = l
+		})
+		return nil
+	}
+}
+
+// AllowedOrigins is a list of origins a cross-domain request can be executed from.
+// If the special "*" value is present in the list, all origins will be allowed.
+// An origin may contain a wildcard (*) to replace 0 or more characters
+// (i.e.: http://*.domain.com). Usage of wildcards implies a small performance penalty.
+// Only one wildcard can be used per origin.
+// Default value is ["*"]
+func SetAllowedOrigins(origins []string) nirvana.Configurer {
+	return func(c *nirvana.Config) error {
+		wrapper(c, func(c *config) {
+			c.AllowedOrigins = origins
+		})
+		return nil
+	}
+}
+
+// AllowOriginFunc is a custom function to validate the origin. It take the origin
+// as argument and returns true if allowed or false otherwise. If this option is
+// set, the content of AllowedOrigins is ignored.
+func SetAllowOriginFunc(f func(origin string) bool) nirvana.Configurer {
+	return func(c *nirvana.Config) error {
+		wrapper(c, func(c *config) {
+			c.AllowOriginFunc = f
+		})
+		return nil
+	}
+}
+
+// AllowOriginRequestFunc is a custom function to validate the origin. It takes the HTTP Request object and the origin as
+// argument and returns true if allowed or false otherwise. If this option is set, the content of `AllowedOrigins`
+// and `AllowOriginFunc` is ignored.
+func SetAllowOriginRequestFunc(f func(r *http.Request, origin string) bool) nirvana.Configurer {
+	return func(c *nirvana.Config) error {
+		wrapper(c, func(c *config) {
+			c.AllowOriginRequestFunc = f
+		})
+		return nil
+	}
+}
+
+type converter func(string) string
+
+// convert converts a list of string using the passed converter function
+func convert(s []string, c converter) []string {
+	out := []string{}
+	for _, i := range s {
+		out = append(out, c(i))
+	}
+	return out
+}
+
+// AllowedMethods is a list of methods the client is allowed to use with
+// cross-domain requests. Default value is simple methods (HEAD, GET and POST).
+func SetAllowedMethods(methods []string) nirvana.Configurer {
+
+	return func(c *nirvana.Config) error {
+		wrapper(c, func(c *config) {
+			if len(methods) == 0 {
+				// Default is spec's "simple" methods
+				c.AllowedMethods = []string{http.MethodGet, http.MethodPost, http.MethodHead}
+			} else {
+				c.AllowedMethods = convert(methods, strings.ToUpper)
+			}
+		})
+		return nil
+	}
+}
+
+// AllowedHeaders is list of non simple headers the client is allowed to use with
+// cross-domain requests.
+// If the special "*" value is present in the list, all headers will be allowed.
+// Default value is [] but "Origin" is always appended to the list.
+func SetAllowedHeaders(headers []string) nirvana.Configurer {
+	return func(c *nirvana.Config) error {
+		wrapper(c, func(c *config) {
+			if len(headers) == 0 {
+				// Use sensible defaults
+				c.AllowedHeaders = []string{"Origin", "Accept", "Content-Type", "X-Requested-With"}
+			}
+			c.AllowedHeaders = headers
+		})
+		return nil
+	}
+}
+
+// ExposedHeaders indicates which headers are safe to expose to the API of a CORS
+// API specification
+func SetExposedHeaders(headers []string) nirvana.Configurer {
+	return func(c *nirvana.Config) error {
+		wrapper(c, func(c *config) {
+			c.ExposedHeaders = headers
+		})
+		return nil
+	}
+}
+
+// MaxAge indicates how long (in seconds) the results of a preflight request
+// can be cached
+func SetMaxAge(age int) nirvana.Configurer {
+	return func(c *nirvana.Config) error {
+		wrapper(c, func(c *config) {
+			c.MaxAge = age
+		})
+		return nil
+	}
+}
+
+// AllowCredentials indicates whether the request can include user credentials like
+// cookies, HTTP authentication or client side SSL certificates.
+
+func SetAllowCredentials(isAllow bool) nirvana.Configurer {
+	return func(c *nirvana.Config) error {
+		wrapper(c, func(c *config) {
+			c.AllowCredentials = isAllow
+		})
+		return nil
+	}
+}
+
+// OptionsPassthrough instructs preflight to let other potential next handlers to
+// process the OPTIONS method. Turn this on if your application handles OPTIONS.
+func SetOptionsPassthrough(isPass bool) nirvana.Configurer {
+	return func(c *nirvana.Config) error {
+		wrapper(c, func(c *config) {
+			c.OptionsPassthrough = isPass
+		})
+		return nil
+	}
+}
+
+// Debugging flag adds additional output to debug server side CORS issues
+func SetDebug(isDebug bool) nirvana.Configurer {
+	return func(c *nirvana.Config) error {
+		wrapper(c, func(c *config) {
+			c.Debug = isDebug
+		})
+		return nil
+	}
+}
+
+func wrapper(c *nirvana.Config, f func(c *config)) {
+	conf := c.Config(ExternalConfigName)
+	var cfg *config
+	if conf == nil {
+		// Default config.
+
+		cfg = &config{
+			Options: cors.Options{
+				AllowedOrigins: []string{"*"},
+			},
+		}
+	} else {
+		// Panic if config type is wrong.
+		cfg = conf.(*config)
+	}
+	f(cfg)
+	c.Set(ExternalConfigName, cfg)
+}
+
+type Option struct {
+	AllowedOrigins         []string
+	AllowOriginFunc        func(origin string) bool
+	AllowOriginRequestFunc func(r *http.Request, origin string) bool
+	AllowedMethods         []string
+	AllowedHeaders         []string
+	ExposedHeaders         []string
+	MaxAge                 int
+	AllowCredentials       bool
+	OptionsPassthrough     bool
+	Debug                  bool
+}
+
+// NewDefaultOption creates default option.
+func NewDefaultOption() *Option {
+	return &Option{
+		AllowedOrigins: []string{"*"},
+	}
+}
+
+func NewOption(opt Option) *Option {
+	return &opt
+}
+
+// Name returns plugin name.
+func (p *Option) Name() string {
+	return ExternalConfigName
+}
+
+// Configure configures nirvana config via current options.
+func (p *Option) Configure(cfg *nirvana.Config) error {
+	cfg.Configure(
+		SetAllowedOrigins(p.AllowedOrigins),
+		SetAllowOriginFunc(p.AllowOriginFunc),
+		SetAllowOriginRequestFunc(p.AllowOriginRequestFunc),
+		SetAllowedMethods(p.AllowedMethods),
+		SetAllowedHeaders(p.AllowedHeaders),
+		SetExposedHeaders(p.ExposedHeaders),
+		SetMaxAge(p.MaxAge),
+		SetAllowCredentials(p.AllowCredentials),
+		SetOptionsPassthrough(p.OptionsPassthrough),
+		SetDebug(p.Debug),
+	)
+	return nil
+}

--- a/plugins/cors/cors.go
+++ b/plugins/cors/cors.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Caicloud Authors
+Copyright 2017 Caicloud Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -75,6 +75,8 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
+# github.com/rs/cors v1.7.0
+github.com/rs/cors
 # github.com/spf13/afero v1.2.2
 github.com/spf13/afero
 github.com/spf13/afero/mem


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add a plugin to handle to handle CORS(Cross-Origin Resource Sharing) related requests(via simple encapsulation of this go package [https://github.com/rs/cors](rs/cors)). All its Supported Options as follow:
  1. set `AllowedOrigins`: a list of origins a cross-domain request can be executed from(for example the domain which hosts front-end pages is different from the back-end domain)
  2. set `AllowedMethods`: A list of methods the client is allowed to use with cross-domain requests(for example: `GET`, `POST`, `PATCH`, `DELETE`)
  3. set `AllowOriginFunc` `func (origin string) bool`: A custom function to validate the origin
  4. set `AllowOriginRequestFunc` `func (r *http.Request origin string) bool`: A custom function to validate the origin
  5. set `AllowedHeaders` `[]string`: A list of non simple headers the client is allowed to use with cross-domain requests.
  6. set `ExposedHeaders` `[]string`: Indicates which headers are safe to expose to the API of a CORS API specification
  7. set `AllowCredentials` bool: Indicates whether the request can include user credentials like cookies, HTTP authentication or client side SSL certificates.
  8. MaxAge int: Indicates how long (in seconds) the results of a preflight request can be cached.
  9. OptionsPassthrough bool: Instructs preflight to let other potential next handlers to process the OPTIONS method. Turn this on if your application handles OPTIONS.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @iawia002 

> Since the `cors` exposes some function fields to public, However due to we cannot add function as command flag, So we need to skip those function fields when nirvana is  calling the register fields methods `registerFields`.

[related code](https://github.com/caicloud/nirvana/blob/master/config/config.go#L333-L492)
https://github.com/caicloud/nirvana/blob/98146ec4aa3cdbada6878d1f560494d15b4c8bf6/config/config.go#L333-L492


**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.

 Error: Access to fetch at 'http://localhost:8080/apis/v1/messages?count=10' from origin 'http://localhost:8081' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.

![image-20210122162116623](https://user-images.githubusercontent.com/5007859/105465565-09101780-5cce-11eb-99a3-e143edb0f76a.png)

3. What's the effects after merging it?

- support cross-domain request 

![image](https://user-images.githubusercontent.com/5007859/105465794-59877500-5cce-11eb-8d9c-16ae17972651.png)
- add a `kind` field to struct configField 
https://github.com/caicloud/nirvana/blob/98146ec4aa3cdbada6878d1f560494d15b4c8bf6/config/config.go#L154-L162

4. Is there anyway we can skip this to not affect the overall process?
Without this new field(`kind`), Is there a way to detect a pointer is function or not during `registerFields`?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

1. Introduce a new dependency [https://github.com/rs/cors](rs/cors)) into go.mod
2. Implement  implementing [http://www.w3.org/TR/cors/](Cross Origin Resource Sharing W3 specification) for `Nirvana`.

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
