### PR TITLE
refactor(*): import API types directly in client generation, no longer copy

### DIFF
--- a/utils/api/comments.go
+++ b/utils/api/comments.go
@@ -30,10 +30,6 @@ const (
 	CommentsOptionDescriptors = "descriptors"
 	// CommentsOptionModifiers is the option name of modifiers.
 	CommentsOptionModifiers = "modifiers"
-	// CommentsOptionAlias is the option name of alias.
-	CommentsOptionAlias = "alias"
-	// CommentsOptionOrigin is the option name of original name.
-	CommentsOptionOrigin = "origin"
 )
 
 // Comments is parsed from go comments.
@@ -43,7 +39,7 @@ type Comments struct {
 }
 
 var optionsRegexp = regexp.MustCompile(`^[ \t]*\+nirvana:api[ \t]*=(.*)$`)
-var options = []string{CommentsOptionDescriptors, CommentsOptionModifiers, CommentsOptionAlias}
+var options = []string{CommentsOptionDescriptors, CommentsOptionModifiers}
 
 // ParseComments parses comments and extracts nirvana options.
 func ParseComments(comments string) *Comments {
@@ -124,40 +120,6 @@ func (c *Comments) LineComments() string {
 		}
 	}
 	return buf.String()
-}
-
-// Rename replaces the first word of this comments. If its first word is
-// not the same as origin, the method returns false.
-func (c *Comments) Rename(origin, target string) bool {
-	if len(c.lines) > 0 {
-		line := c.lines[0]
-		if strings.HasPrefix(line, origin) {
-			line = target + line[len(origin):]
-			c.lines[0] = line
-			return true
-		}
-	}
-	return false
-}
-
-// Options returns all options.
-func (c *Comments) Options() map[string][]string {
-	return c.options
-}
-
-// Option returns values of an option.
-func (c *Comments) Option(name string) []string {
-	return c.options[name]
-}
-
-// AddOption adds an option.
-func (c *Comments) AddOption(name, value string) {
-	c.options[name] = append(c.options[name], value)
-}
-
-// CleanOptions removes all options.
-func (c *Comments) CleanOptions() {
-	c.options = map[string][]string{}
 }
 
 // String returns comments.

--- a/utils/generators/golang/generator.go
+++ b/utils/generators/golang/generator.go
@@ -18,7 +18,6 @@ package golang
 
 import (
 	"bytes"
-	"fmt"
 	"go/format"
 	"path"
 	"strings"
@@ -71,17 +70,11 @@ func (g *Generator) Generate() (map[string][]byte, error) {
 		}
 		// all lower case string
 		packageName := d.Version.Module + d.Version.Name
-		types, imports := helper.Types()
-		typeCodes, err := g.typeCodes(packageName, types, imports)
-		if err != nil {
-			return nil, err
-		}
 		functions, imports := helper.Functions()
 		functionCodes, err := g.functionCodes(packageName, functions, imports)
 		if err != nil {
 			return nil, err
 		}
-		codes[packageName+"/types"] = typeCodes
 		codes[packageName+"/client"] = functionCodes
 	}
 	client, err := g.aggregationClientCode(versions)
@@ -90,29 +83,6 @@ func (g *Generator) Generate() (map[string][]byte, error) {
 	}
 	codes["client"] = client
 	return codes, nil
-}
-
-func (g *Generator) typeCodes(version string, types []Type, imports []string) ([]byte, error) {
-	data := bytes.NewBufferString(fmt.Sprintf("package %s\n", version))
-	writeln := func(str string) {
-		_, err := fmt.Fprintln(data, str)
-		// Ignore this error.
-		_ = err
-	}
-
-	if len(imports) > 0 {
-		writeln("import (")
-		for _, pkg := range imports {
-			writeln(pkg)
-		}
-		writeln(")")
-	}
-
-	for _, typ := range types {
-		writeln("")
-		writeln(string(typ.Generate()))
-	}
-	return format.Source(data.Bytes())
 }
 
 func (g *Generator) functionCodes(version string, functions []function, imports []string) ([]byte, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Previously, generating a client copies all the built-in types, this PR changes the processing method to directly import the corresponding types to solve the type duplication problem and speed up the client generation speed.

The effect is as follows:

```diff
diff --git a/pkg/server/client/v20201010/client.go b/pkg/server/client/v20201010/client.go
index 8779df2..adbb782 100644
--- a/pkg/server/client/v20201010/client.go
+++ b/pkg/server/client/v20201010/client.go
@@ -2,6 +2,9 @@ package v20201010

 import (
 	"context"
+	addon "github.com/caicloud/module-template/pkg/server/apis/addon"
+	app "github.com/caicloud/module-template/pkg/server/apis/app"
+	storage "github.com/caicloud/module-template/pkg/server/apis/storage"

 	rest "github.com/caicloud/nirvana/rest"
 )
@@ -10,19 +13,19 @@ import (
 type Interface interface {
 	// GetStorageObject description:
 	// Get a object by id
-	GetStorageObject(ctx context.Context, iD int) (storageObject *StorageObject, err error)
+	GetStorageObject(ctx context.Context, iD int) (storageObject *storage.Object, err error)
 	// GetWorkload description:
 	// Get a workload by id
-	GetWorkload(ctx context.Context, name string) (workload *Workload, err error)
+	GetWorkload(ctx context.Context, name string) (appWorkload *app.Workload, err error)
 	// ListAddonObjects description:
 	// Query a specified number of objects and returns an array
-	ListAddonObjects(ctx context.Context, count int) (objects []Object, err error)
+	ListAddonObjects(ctx context.Context, count int) (addonObjects []addon.Object, err error)
 	// ListStorageObjects description:
 	// Query a specified number of objects and returns an array
-	ListStorageObjects(ctx context.Context, count int) (storageObjects []StorageObject, err error)
+	ListStorageObjects(ctx context.Context, count int) (storageObjects []storage.Object, err error)
 	// ListWorkloads description:
 	// Query a specified number of workloads and returns an array
-	ListWorkloads(ctx context.Context, count int) (workloads []Workload, err error)
+	ListWorkloads(ctx context.Context, count int) (appWorkloads []app.Workload, err error)
 }

 // Client for version v20201010.
@@ -50,8 +53,8 @@ func MustNewClient(cfg *rest.Config) *Client {

 // GetStorageObject description:
 // Get a object by id
-func (c *Client) GetStorageObject(ctx context.Context, iD int) (storageObject *StorageObject, err error) {
-	storageObject = new(StorageObject)
+func (c *Client) GetStorageObject(ctx context.Context, iD int) (storageObject *storage.Object, err error) {
+	storageObject = new(storage.Object)
 	err = c.rest.Request("POST", 200, "/?Version=2020-10-10&Action=GetStorageObject").
 		Query("ID", iD).
 		TOPRPCData(storageObject).
@@ -61,28 +64,28 @@ func (c *Client) GetStorageObject(ctx context.Context, iD int) (storageObject *S

 // GetWorkload description:
 // Get a workload by id
-func (c *Client) GetWorkload(ctx context.Context, name string) (workload *Workload, err error) {
-	workload = new(Workload)
+func (c *Client) GetWorkload(ctx context.Context, name string) (appWorkload *app.Workload, err error) {
+	appWorkload = new(app.Workload)
 	err = c.rest.Request("POST", 200, "/?Version=2020-10-10&Action=GetWorkload").
 		Query("Name", name).
-		TOPRPCData(workload).
+		TOPRPCData(appWorkload).
 		Do(ctx)
 	return
 }

 // ListAddonObjects description:
 // Query a specified number of objects and returns an array
-func (c *Client) ListAddonObjects(ctx context.Context, count int) (objects []Object, err error) {
+func (c *Client) ListAddonObjects(ctx context.Context, count int) (addonObjects []addon.Object, err error) {
 	err = c.rest.Request("POST", 200, "/?Version=2020-10-10&Action=ListAddonObjects").
 		Query("Count", count).
-		TOPRPCData(&objects).
+		TOPRPCData(&addonObjects).
 		Do(ctx)
 	return
 }

 // ListStorageObjects description:
 // Query a specified number of objects and returns an array
-func (c *Client) ListStorageObjects(ctx context.Context, count int) (storageObjects []StorageObject, err error) {
+func (c *Client) ListStorageObjects(ctx context.Context, count int) (storageObjects []storage.Object, err error) {
 	err = c.rest.Request("POST", 200, "/?Version=2020-10-10&Action=ListStorageObjects").
 		Query("Count", count).
 		TOPRPCData(&storageObjects).
@@ -92,10 +95,10 @@ func (c *Client) ListStorageObjects(ctx context.Context, count int) (storageObje

 // ListWorkloads description:
 // Query a specified number of workloads and returns an array
-func (c *Client) ListWorkloads(ctx context.Context, count int) (workloads []Workload, err error) {
+func (c *Client) ListWorkloads(ctx context.Context, count int) (appWorkloads []app.Workload, err error) {
 	err = c.rest.Request("POST", 200, "/?Version=2020-10-10&Action=ListWorkloads").
 		Query("Count", count).
-		TOPRPCData(&workloads).
+		TOPRPCData(&appWorkloads).
 		Do(ctx)
 	return
 }
diff --git a/pkg/server/client/v20201010/types.go b/pkg/server/client/v20201010/types.go
deleted file mode 100644
index a75ac58..0000000
--- a/pkg/server/client/v20201010/types.go
+++ /dev/null
@@ -1,18 +0,0 @@
-package v20201010
-
-// Object describes a object entry.
-type Object struct {
-	ID int `json:"Id"`
-}
-
-// StorageObject describes a object entry.
-//
-// +nirvana:api=origin:"Object"
-type StorageObject struct {
-	ID int `json:"Id"`
-}
-
-// Workload describes a workload entry.
-type Workload struct {
-	Name string `json:"Name"`
-}
```

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @xpofei 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
