### PR TITLE
add missing openapi 2.0 operationid

### DIFF
--- a/definition/definition.go
+++ b/definition/definition.go
@@ -206,6 +206,8 @@ type Result struct {
 
 // Definition defines an API handler.
 type Definition struct {
+	// OperationID is Unique string used to identify the operation. The OperationID MUST be unique among all operations described in the API.
+	OperationID string
 	// Method is definition method.
 	Method Method
 	// Consumes indicates how many content types the handler can consume.

--- a/service/rest/builder.go
+++ b/service/rest/builder.go
@@ -131,6 +131,7 @@ func (b *builder) addDescriptor(prefix string, consumes []string, produces []str
 func (b *builder) copyDefinition(d *definition.Definition, consumes []string, produces []string, tags []string) *definition.Definition {
 	newOne := &definition.Definition{
 		Method:      d.Method,
+		OperationID: d.OperationID,
 		Summary:     d.Summary,
 		Function:    d.Function,
 		Description: d.Description,

--- a/utils/api/definitions.go
+++ b/utils/api/definitions.go
@@ -101,6 +101,7 @@ func NewDefinition(tc *TypeContainer, d *definition.Definition, apiStyle service
 		Method:        d.Method,
 		HTTPMethod:    service.HTTPMethodFor(d.Method),
 		HTTPCode:      code,
+		OperationID:   d.OperationID,
 		Summary:       d.Summary,
 		Description:   d.Description,
 		Tags:          d.Tags,

--- a/utils/api/definitions.go
+++ b/utils/api/definitions.go
@@ -60,6 +60,8 @@ type Definition struct {
 	HTTPMethod string
 	// HTTPCode is http success code.
 	HTTPCode int
+	// OperationID is Unique string used to identify the operation. The OperationID MUST be unique among all operations described in the API.
+	OperationID string
 	// Summary is a brief of this definition.
 	Summary string
 	// Description describes the API handler.

--- a/utils/generators/swagger/generator.go
+++ b/utils/generators/swagger/generator.go
@@ -433,6 +433,7 @@ func (g *Generator) operationFor(def *api.Definition) *spec.Operation {
 			operation.Produces = append(operation.Produces, p)
 		}
 	}
+	operation.ID = def.OperationID
 	operation.Summary = def.Summary
 	if operation.Summary == "" {
 		// Use function name as API summary.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add openapi 2.0 specs' missing `operationid` field.
See spec docs: https://swagger.io/docs/specification/paths-and-operations/ (search operationId) here.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:


<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
